### PR TITLE
Pin rspec-expectations due to private API change

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-cli"
   s.add_dependency "fauxhai-chef", ">= 9.3"
   s.add_dependency "rspec",   "~> 3.0"
+  s.add_dependency "rspec-expectations", "3.12.3"
 end


### PR DESCRIPTION
## Description

In this change, we are introducing a temporary version pin of the rspec-expectations gem to version v3.12.3.

As part of the v3.12.3/v3.13.0 releases, the private API class RSpec::Matchers::ExpectedsForMultipleDiffs was renamed to RSpec::Matchers::MultiMatcherDiff [1]. chefspec does make use of this class in one instance.

A future change should be introduced to properly address this class dependency. Possible options include replicating a minimal replacement, or porting the class to equivalent custom matcher with the chefspec codebase.

[1]: https://github.com/rspec/rspec-expectations/commit/d0bb212

## Related Issue

Here is an example of a spec failing within a CD/CI pipeline that automatically pulls in the latest version of the chefspec gem. Note, that chefspec did not have a new release, but the permissive version matching against rspec now introduces this runtime error.

```
An error occurred while loading ./spec/_configure_yum_vars_cron_spec.rb.
Failure/Error: require 'chefspec'

LoadError:

  cannot load such file -- rspec/matchers/expecteds_for_multiple_diffs
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers/resource_matcher.rb:1:in `require'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers/resource_matcher.rb:1:in `<top (required)>'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:9:in `require_relative'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:9:in `<module:Matchers>'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:2:in `<module:ChefSpec>'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec/matchers.rb:1:in `<top (required)>'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec.rb:66:in `require_relative'
# /usr/local/rvm/gems/ruby-2.7.6/gems/chefspec-9.3.6/lib/chefspec.rb:66:in `<top (required)>'
# ./spec/_configure_yum_vars_cron_spec.rb:1:in `require'
# ./spec/_configure_yum_vars_cron_spec.rb:1:in `<top (required)>'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
