### PR TITLE
Adding chef/chef's CODEOWNERS to chefspec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Order is important. The last matching pattern has the most precedence.
+
+*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
+.expeditor/  @chef/build-engineering-systems-team


### PR DESCRIPTION
It (at least currently) falls under chef-infra-client owners

Signed-off-by: Phil Dibowitz <phil@ipom.com>
