### PR TITLE
Misspelling of 'receive' broke downstream

### DIFF
--- a/lib/chefspec/api/core.rb
+++ b/lib/chefspec/api/core.rb
@@ -22,7 +22,7 @@ module ChefSpec
       end
 
       before do
-        allow(::Chef).to recieve(:node).and_return(chef_node) if chefspec_platform
+        allow(::Chef).to receive(:node).and_return(chef_node) if chefspec_platform
       end
 
       # Let variables to set data in a scoped way. Used below by


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[#9](https://github.com/chef/chefspec/pull/9) contained a misspelling of the word "receive" which breaks chefspec tests in chef/chef


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
