### PR TITLE
Fix NameError from removed rspec-expectations diff class (#13)

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -31,7 +31,4 @@ Gem::Specification.new do |s|
   # this needs to be remedied before Ruby 3.3
   s.add_dependency "logger", "< 1.6"
   s.add_development_dependency "cookstyle", "~> 8.4"
-
-  # temporary restriction to a version of rspec-expectations that includes the
-  # `RSpec::Matchers::ExpectedsForMultipleDiffs` class (renamed in 3.12.4)
 end

--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -1,4 +1,3 @@
-# require "rspec/matchers/expecteds_for_multiple_diffs" This is now a private class and will throw errors when the require statement is executed
 require "rspec/expectations/fail_with"
 
 module ChefSpec::Matchers
@@ -66,8 +65,7 @@ module ChefSpec::Matchers
             "\n\n" \
             "  " + unmatched_parameters.collect { |parameter, h|
               msg = "#{parameter} #{h[:expected].inspect}, was #{h[:actual].inspect}"
-              diff = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(h[:expected]) \
-                .message_with_diff(message, ::RSpec::Expectations.differ, h[:actual])
+              diff = diff_for(h[:expected], h[:actual], message)
               msg += diff if diff
               msg
             }.join("\n  ")
@@ -94,6 +92,27 @@ module ChefSpec::Matchers
     end
 
     private
+
+    #
+    # Build the diff text for a mismatched parameter using rspec-expectations'
+    # private diff helper. That helper was renamed and its signature changed in
+    # rspec-expectations 3.12.4 (`ExpectedsForMultipleDiffs.from(expected)` with
+    # `message_with_diff(message, differ, actual)` became
+    # `MultiMatcherDiff.from(expected, actual)` with
+    # `message_with_diff(message, differ)`), so support both shapes.
+    #
+    # @return [String, nil]
+    #
+    def diff_for(expected, actual, message)
+      differ = ::RSpec::Expectations.differ
+      if defined?(::RSpec::Matchers::MultiMatcherDiff)
+        ::RSpec::Matchers::MultiMatcherDiff.from(expected, actual)
+          .message_with_diff(message, differ)
+      else
+        ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(expected)
+          .message_with_diff(message, differ, actual)
+      end
+    end
 
     def unmatched_parameters
       return @_unmatched_parameters if @_unmatched_parameters

--- a/spec/unit/matchers/resource_matcher_spec.rb
+++ b/spec/unit/matchers/resource_matcher_spec.rb
@@ -1,5 +1,30 @@
 require "spec_helper"
 
 describe ChefSpec::Matchers::ResourceMatcher do
-  pending
+  subject { described_class.new(:template, :create, "/etc/foo") }
+
+  describe "#failure_message" do
+    context "when a resource is found but has unmatched parameters" do
+      before do
+        # Pretend we found a matching resource with a mismatched, multi-line
+        # parameter so that #failure_message renders a diff. This is the code
+        # path that depends on rspec-expectations' (private) diff helper class.
+        allow(subject).to receive(:resource).and_return("template[/etc/foo]")
+        allow(subject).to receive(:unmatched_parameters).and_return(
+          content: { expected: "line one\nline two\n", actual: "line one\nline three\n" }
+        )
+      end
+
+      it "renders a diff without raising" do
+        expect { subject.failure_message }.not_to raise_error
+      end
+
+      it "includes the parameter name and a diff in the message" do
+        message = subject.failure_message
+        expect(message).to include("expected \"template[/etc/foo]\" to have parameters")
+        expect(message).to include("content")
+        expect(message).to include("line three")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Resolves #13.

rspec-expectations renamed its private diff helper class from `ExpectedsForMultipleDiffs` to `MultiMatcherDiff` in 3.12.4 and changed its signature (`actual` moved from `message_with_diff` into the `from` factory). The originally reported error was a `LoadError` on `require "rspec/matchers/expecteds_for_multiple_diffs"`.

A prior change (#19) addressed the `LoadError` by removing the `rspec-expectations <= 3.12.3` pin and commenting out the broken `require` — but it left the call site in `ResourceMatcher#failure_message` still referencing the removed `::RSpec::Matchers::ExpectedsForMultipleDiffs` class. That turned the loud `LoadError` into a **latent `NameError`** that only fires when a resource-parameter assertion fails and chefspec tries to render a diff.

## Changes

- **`lib/chefspec/matchers/resource_matcher.rb`**: Remove the stale commented-out `require`; extract a `diff_for` helper that detects which private rspec class is available and calls the matching API. This keeps chefspec working across the full `rspec ~> 3.0` range (old and new rspec-expectations).
- **`chefspec.gemspec`**: Drop the dangling "temporary restriction" comment that described a version pin already removed.
- **`spec/unit/matchers/resource_matcher_spec.rb`**: Replace the `pending` stub with a real test covering the diff-rendering failure path (regression test for this issue).

## Testing

- Reproduced the `NameError` with a failing test first, then confirmed the fix (green) against rspec-expectations 3.13.5.
- Manually verified the legacy branch produces a correct diff against rspec-expectations 3.11.1.
- Full unit suite: `163 examples, 0 failures`.
- Lint: `cookstyle --chefstyle -c .rubocop.yml` → no offenses.