### PR TITLE
Refresh README: fix stale versions, links, and Travis references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ChefSpec
 
 [![Gem Version](https://badge.fury.io/rb/chefspec.svg)](https://badge.fury.io/rb/chefspec)
-[![CI](https://github.com/chefspec/chefspec/actions/workflows/ci.yml/badge.svg)](https://github.com/chefspec/chefspec/actions/workflows/ci.yml)
+[![CI](https://github.com/chef/chefspec/actions/workflows/ci.yml/badge.svg)](https://github.com/chef/chefspec/actions/workflows/ci.yml)
 
 ChefSpec is a unit testing framework for testing Chef cookbooks. ChefSpec makes it easy to write examples and get fast feedback on cookbook changes without the need for virtual machines or cloud servers.
 
@@ -12,14 +12,12 @@ ChefSpec runs your cookbooks locally while skipping making actual changes. This 
 
 ## Important Notes
 
-- **ChefSpec requires Ruby 2.5 or later and Chef 15 or later!**
+- **ChefSpec requires Ruby 3.1 or later and Chef 17 or later!**
 - **This documentation corresponds to the main branch, which may be unreleased. Please check the README of the latest git tag or the gem's source for your version's documentation!**
 
 **ChefSpec aims to maintain compatibility with at least the two most recent minor versions of Chef.** If you are running an older version of Chef it may work, or you will need to run an older version of ChefSpec.
 
-As a general rule, if it is tested in the Travis CI matrix, it is a supported version.
-
-## Quick Start
+As a general rule, if it is tested in the [GitHub Actions](https://github.com/chef/chefspec/actions) CI matrix, it is a supported version.
 
 ## When To Use ChefSpec?
 
@@ -581,7 +579,7 @@ end
 All the ruby methods off of the File, Dir and FileUtils classes along with any other global class methods that the
 client might use, should follow a similar pattern for stubbing.
 
-Check out the [RSpec Mocks documentation](https://relishapp.com/rspec/rspec-mocks/docs)
+Check out the [RSpec Mocks documentation](https://rspec.info/documentation/)
 for more information about setting up Ruby method stubs.
 
 ## Development
@@ -609,13 +607,13 @@ for more information about setting up Ruby method stubs.
 
 8. Open a Pull Request
 
-ChefSpec is on [Travis CI][travis] which tests against multiple Chef and Ruby versions.
+ChefSpec is tested via [GitHub Actions](https://github.com/chef/chefspec/actions) against multiple Ruby versions.
 
-If you are contributing, please see the [Contributing Guidelines](https://github.com/chefspec/chefspec/blob/main/CONTRIBUTING.md) for more information.
+If you are contributing, please see the [Contributing Guidelines](https://github.com/chef/chefspec/blob/main/CONTRIBUTING.md) for more information.
 
 ## License
 
-MIT - see the accompanying [LICENSE](https://github.com/chefspec/chefspec/blob/main/LICENSE) file for details.
+MIT - see the accompanying [LICENSE](https://github.com/chef/chefspec/blob/main/LICENSE) file for details.
 
 # Copyright
 See [COPYRIGHT.md](./COPYRIGHT.md).


### PR DESCRIPTION
## Summary

Brings the README in line with the current state of the project. This fixes recommendation #3 from the earlier modernization review (the README contradicted the gemspec and still referenced Travis) plus a few related cleanups.

## Changes

- **Supported versions.** Updated the "Important Notes" line from *"Ruby 2.5 or later and Chef 15 or later"* to *"Ruby 3.1 or later and Chef 17 or later"*, matching `required_ruby_version` and the `chef` dependency in `chefspec.gemspec`.
- **Travis → GitHub Actions.** Replaced both Travis CI mentions with GitHub Actions. Note the footer used a `[Travis CI][travis]` reference-style link whose `[travis]:` definition didn't exist, so it was rendering as broken literal text.
- **Org rename.** Fixed the CI badge and all repo links from the old `chefspec/chefspec` org to `chef/chefspec` (the badge was pointing at a non-existent workflow and showing as broken).
- **Empty section.** Removed the empty `## Quick Start` heading (it had no content; the following "When To Use" / custom-resource walkthrough already serves as the getting-started material).
- **Dead link.** Updated the RSpec Mocks documentation link from the retired `relishapp.com` to `rspec.info`.