### PR TITLE
Replace Proc.new with proc

### DIFF
--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -10,7 +10,7 @@ module ChefSpec
   # @return [self]
   #
   def define_matcher(resource_name)
-    matchers[resource_name.to_sym] = Proc.new do |identity|
+    matchers[resource_name.to_sym] = proc do |identity|
       find_resource(resource_name, identity)
     end
 

--- a/lib/chefspec/matchers/notifications_matcher.rb
+++ b/lib/chefspec/matchers/notifications_matcher.rb
@@ -12,7 +12,7 @@ module ChefSpec::Matchers
       @resource = resource
 
       if @resource
-        block = Proc.new do |notified|
+        block = proc do |notified|
           resource_name(notified.resource).to_s == @expected_resource_type &&
             (@expected_resource_name === notified.resource.identity.to_s || @expected_resource_name === notified.resource.name.to_s) &&
             matches_action?(notified)

--- a/lib/chefspec/stubs/stub.rb
+++ b/lib/chefspec/stubs/stub.rb
@@ -9,7 +9,7 @@ module ChefSpec
       end
 
       def and_raise(exception)
-        @block = Proc.new { raise exception }
+        @block = proc { raise exception }
         self
       end
 


### PR DESCRIPTION
## Summary

Replaces the three remaining uses of `Proc.new` with the `proc` Kernel method:

- `lib/chefspec.rb` (`define_matcher`)
- `lib/chefspec/stubs/stub.rb` (`and_raise`)
- `lib/chefspec/matchers/notifications_matcher.rb` (`matches?`)

`Proc.new` is a legacy idiom — calling it without a block was deprecated and removed in modern Ruby, and the explicit constructor offers nothing over `proc { ... }`. This is a behavior-preserving readability/future-proofing cleanup.

## Testing

- `bundle exec rspec spec/unit/` → `162 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml` on the changed files → no offenses.