### PR TITLE
Test the full supported Ruby range in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
     name: Test with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Expands the CI Ruby matrix from `['3.1', '3.4']` to `['3.1', '3.2', '3.3', '3.4']`.

The matrix previously only tested the two endpoints of the supported range, so a regression specific to Ruby 3.2 or 3.3 — both fully supported per the gemspec's `required_ruby_version >= 3.1` — could land undetected. Testing every minor in range closes that gap.

## Notes

- This intentionally stays focused on the Ruby matrix. Adding OS coverage (e.g. `windows-latest`, given ChefSpec's many Windows-specific resources) would be a worthwhile but separate change, since Windows runs need their own validation.