### PR TITLE
Pin GitHub Actions to commit SHAs and let Dependabot update them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         ruby: [ '3.1', '3.4' ]
     name: Test with Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: 3.1
           bundler-cache: false
-      - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
+      - uses: r7kamura/rubocop-problem-matchers-action@59f1a0759f50cc2649849fd850b8487594bb5a81 # v1.2.2 — shows the failures in the PR
       - run: |
           gem install cookstyle
           cookstyle --chefstyle -c .rubocop.yml


### PR DESCRIPTION
## Summary

Hardens and modernizes the GitHub Actions pinning, and sets up Dependabot to keep it current.

### Pin actions to commit SHAs
Both workflows referenced actions by mutable major tags, which had also drifted out of sync — `actions/checkout` was `@v6` in `ci.yml` but `@v4` in `lint.yml`. A tag can be force-pushed to point at new code after a maintainer (or attacker) changes it, so a tag is not an immutable pin. Each action is now pinned to a full-length commit SHA at its current latest release, with a trailing version comment:

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v7.0.0 | `9c091bb…` |
| `ruby/setup-ruby` | v1.314.0 | `9eb537c…` |
| `r7kamura/rubocop-problem-matchers-action` | v1.2.2 | `59f1a07…` |

### Keep them updated with Dependabot
Added a `github-actions` ecosystem to `.github/dependabot.yml`. Dependabot understands SHA-pinned actions and will open PRs that bump both the SHA and the version comment as new releases ship, so pinning no longer means going stale.

### Cooldown
Added a 7-day `cooldown` to both the existing `bundler` ecosystem and the new `github-actions` ecosystem, so Dependabot waits a week before proposing newly published versions — a guard against pulling in a freshly compromised or unstable release.

## Notes

- This touches `lint.yml`, which is also modified by #34 (cookstyle-via-bundler). Whichever merges first, the other will need a trivial rebase on the `uses:` lines.