### PR TITLE
Add metadata links to the gemspec

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -17,6 +17,13 @@ Gem::Specification.new do |s|
   s.homepage      = "https://github.com/chef/chefspec"
   s.license       = "MIT"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/chef/chefspec",
+    "changelog_uri" => "https://github.com/chef/chefspec/blob/main/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/chef/chefspec/issues",
+    "documentation_uri" => "https://github.com/chef/chefspec/blob/main/README.md",
+  }
+
   # Packaging
   s.files         = %w{LICENSE Rakefile Gemfile chefspec.gemspec} + Dir.glob("{lib,templates,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
## Summary

Adds a `metadata` block to `chefspec.gemspec` so [rubygems.org/gems/chefspec](https://rubygems.org/gems/chefspec) renders the standard sidebar links (source, changelog, issues, docs) instead of just the homepage.

```ruby
s.metadata = {
  "source_code_uri"   => "https://github.com/chef/chefspec",
  "changelog_uri"     => "https://github.com/chef/chefspec/blob/main/CHANGELOG.md",
  "bug_tracker_uri"   => "https://github.com/chef/chefspec/issues",
  "documentation_uri" => "https://github.com/chef/chefspec/blob/main/README.md",
}
```

## Notes

- `homepage_uri` is intentionally omitted — it would duplicate the existing `s.homepage` and `source_code_uri` (RubyGems warns when two metadata keys share a URL).
- `rubygems_mfa_required` was deliberately left out: it requires an OTP on push and could break the automated Expeditor publish pipeline. That's a maintainer/release-policy decision better made separately.

## Testing

- `Gem::Specification.load("chefspec.gemspec").validate` → valid, no warnings.
- `cookstyle --chefstyle -c .rubocop.yml chefspec.gemspec` → no offenses.