### PR TITLE
Remove dead pre-Chef-15 branches from the monkey patches

### DIFF
--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -7,9 +7,6 @@ module ChefSpec
       # Pull in the needed machinery to use `before` here.
       extend RSpec::SharedContext
 
-      # Which version to use the shell_out_compacted hook on.
-      HAS_SHELLOUT_COMPACTED = Gem::Requirement.create("> 14.2")
-
       # Hook used in the monkey patches to set up a place to inject stubs when
       # needed for a resource or provider.
       #
@@ -97,12 +94,8 @@ module ChefSpec
           @stderr = stderr
           @status = fake_exitstatus
         end
-        # On newer Chef, we can intercept using the new, better shell_out_compact hook point.
-        shell_out_method ||= if HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-                               :shell_out_compacted
-                             else
-                               :shell_out
-                             end
+        # Intercept using the shell_out_compacted hook point.
+        shell_out_method ||= :shell_out_compacted
         with_args = cmd + (opts.empty? ? [any_args] : [hash_including(opts)])
         receive(shell_out_method).with(*with_args).and_return(fake_cmd)
       end

--- a/lib/chefspec/extensions/chef/lwrp_base.rb
+++ b/lib/chefspec/extensions/chef/lwrp_base.rb
@@ -3,27 +3,10 @@
 # collection.  Chefspec needs to be taught how to deal with
 # sub-resource collections.
 
-if defined?(Chef::Provider::InlineResources)
-  Chef::Provider::InlineResources.prepend(Module.new do
-    def initialize(resource, run_context)
-      super
-      @run_context = run_context
-      @resource_collection = run_context.resource_collection
-    end
-  end)
+Chef::Provider.prepend(Module.new do
+  def compile_and_converge_action(&block)
+    return super unless $CHEFSPEC_MODE
 
-  Chef::Provider::InlineResources::ClassMethods.prepend(Module.new do
-    def action(name, &block)
-      # Note: This does not check $CHEFSPEC_MODE.
-      define_method("action_#{name}", &block)
-    end
-  end)
-else # >= 13.0
-  Chef::Provider.prepend(Module.new do
-    def compile_and_converge_action(&block)
-      return super unless $CHEFSPEC_MODE
-
-      instance_eval(&block)
-    end
-  end)
-end
+    instance_eval(&block)
+  end
+end)

--- a/lib/chefspec/extensions/chef/provider.rb
+++ b/lib/chefspec/extensions/chef/provider.rb
@@ -17,23 +17,15 @@ Chef::Provider.prepend(Module.new do
   end
 
   # Defang shell_out and friends so it can never run.
-  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-    def shell_out_compacted(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted(*args)
+    return super unless $CHEFSPEC_MODE
 
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "provider", resource: new_resource)
-    end
+    raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "provider", resource: new_resource)
+  end
 
-    def shell_out_compacted!(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted!(*args)
+    return super unless $CHEFSPEC_MODE
 
-      shell_out_compacted(*args).tap(&:error!)
-    end
-  else
-    def shell_out(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "provider", resource: new_resource)
-    end
+    shell_out_compacted(*args).tap(&:error!)
   end
 end)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -8,24 +8,16 @@ module ::ChefSpec::Extensions::Chef::ResourceShellOut
   #
   # Defang shell_out and friends so it can never run.
   #
-  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-    def shell_out_compacted(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted(*args)
+    return super unless $CHEFSPEC_MODE
 
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
+    raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+  end
 
-    def shell_out_compacted!(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted!(*args)
+    return super unless $CHEFSPEC_MODE
 
-      shell_out_compacted(*args).tap(&:error!)
-    end
-  else
-    def shell_out(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
+    shell_out_compacted(*args).tap(&:error!)
   end
 end
 
@@ -33,24 +25,16 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
   #
   # Defang shell_out and friends so it can never run.
   #
-  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-    def shell_out_compacted(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted(*args)
+    return super unless $CHEFSPEC_MODE
 
-      raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
-    end
+    raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
+  end
 
-    def shell_out_compacted!(*args)
-      return super unless $CHEFSPEC_MODE
+  def shell_out_compacted!(*args)
+    return super unless $CHEFSPEC_MODE
 
-      shell_out_compacted(*args).tap(&:error!)
-    end
-  else
-    def shell_out(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
-    end
+    shell_out_compacted(*args).tap(&:error!)
   end
 end
 


### PR DESCRIPTION
## Summary

The gemspec requires `chef >= 17`, which makes several version-conditional branches inside the extension monkey patches permanently unreachable. This removes that dead code, simplifying the most version-fragile part of ChefSpec.

### What was dead, and why
- **`extensions/chef/lwrp_base.rb`** branched on `defined?(Chef::Provider::InlineResources)`. `InlineResources` was removed in Chef 13.0 (the code's own `else # >= 13.0` comment notes this), so at Chef ≥ 17 only the `compile_and_converge_action` branch can run.
- **`extensions/chef/provider.rb`** and **`extensions/chef/shell_out.rb`** (both `ResourceShellOut` and `MixinShellOut`) branched on `HAS_SHELLOUT_COMPACTED = Gem::Requirement.create("> 14.2")`. At Chef ≥ 17 that's always satisfied, so the legacy `shell_out` fallbacks are dead and only the `shell_out_compacted` hooks remain.
- **`api/stubs_for.rb`** selected the hook method with the same always-true check, and defined the now-unused `HAS_SHELLOUT_COMPACTED` constant.

### Changes
- Dropped the unreachable branches in all four files.
- Removed the unused `HAS_SHELLOUT_COMPACTED` constant.
- No behavior change on supported Chef versions.

## Testing
- `bundle exec rspec spec/unit/` → `162 examples, 0 failures`.
- Acceptance examples that exercise the patched paths:
  - `stubs_for` + `execute` (drive `shell_out_compacted`) → `41 examples, 0 failures`.
  - `custom_resource`, `custom_resource_block`, `heavy_provider_light_resource` (drive `compile_and_converge_action`) → `7 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml` on the changed files → no offenses.