### PR TITLE
Add respond_to_missing? to ResourceMatcher

### DIFF
--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -39,6 +39,10 @@ module ChefSpec::Matchers
       end
     end
 
+    def respond_to_missing?(m, include_private = false)
+      m.to_s.match?(/^with_(.+)$/) || super
+    end
+
     def description
       %Q{#{@expected_action} #{@resource_name} "#{@expected_identity}"}
     end

--- a/spec/unit/matchers/resource_matcher_spec.rb
+++ b/spec/unit/matchers/resource_matcher_spec.rb
@@ -27,4 +27,14 @@ describe ChefSpec::Matchers::ResourceMatcher do
       end
     end
   end
+
+  describe "#respond_to?" do
+    it "reports responding to dynamic with_* matcher methods" do
+      expect(subject).to respond_to(:with_owner)
+    end
+
+    it "does not report responding to unrelated missing methods" do
+      expect(subject).not_to respond_to(:nonexistent_method)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`ResourceMatcher#method_missing` provides the dynamic `with_*(value)` matcher sugar, but there was no corresponding `respond_to_missing?`. As a result `matcher.respond_to?(:with_owner)` returned `false` even though the call works — the object lied about its own interface, which trips up `respond_to?`-based introspection and serialization libraries.

This adds `respond_to_missing?` mirroring the `method_missing` regex, the same pattern already used in `SoloRunner#respond_to_missing?` (`solo_runner.rb`).

## Testing

- Added a unit spec (TDD — verified it failed first) covering both that the matcher reports responding to `with_*` methods and that it does not claim unrelated methods.
- `bundle exec rspec spec/unit/` → `163 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml` → no offenses.

## Note

This touches `spec/unit/matchers/resource_matcher_spec.rb`, which is also rewritten by #31 (the rspec-expectations fix replaced its `pending` stub). Whichever merges first, the other needs a trivial merge of the two example groups.