### PR TITLE
Use explicit MatchData captures instead of regex globals

### DIFF
--- a/lib/chefspec/matchers/notifications_matcher.rb
+++ b/lib/chefspec/matchers/notifications_matcher.rb
@@ -3,9 +3,9 @@ module ChefSpec::Matchers
     include ChefSpec::Normalize
 
     def initialize(signature)
-      signature.match(/^([^\[]*)\[(.*)\]$/)
-      @expected_resource_type = $1
-      @expected_resource_name = $2
+      match = signature.match(/^([^\[]*)\[(.*)\]$/)
+      @expected_resource_type = match[1]
+      @expected_resource_name = match[2]
     end
 
     def matches?(resource)

--- a/lib/chefspec/matchers/subscribes_matcher.rb
+++ b/lib/chefspec/matchers/subscribes_matcher.rb
@@ -3,9 +3,9 @@ module ChefSpec::Matchers
     include ChefSpec::Normalize
 
     def initialize(signature)
-      signature.match(/^([^\[]*)\[(.*)\]$/)
-      @expected_resource_type = $1
-      @expected_resource_name = $2
+      match = signature.match(/^([^\[]*)\[(.*)\]$/)
+      @expected_resource_type = match[1]
+      @expected_resource_name = match[2]
     end
 
     def matches?(resource)


### PR DESCRIPTION
## Summary

`SubscribesMatcher` and `NotificationsMatcher` parsed their `type[name]` signature by calling `String#match` purely for its side effect and then reading the magic `$1` / `$2` global match variables:

```ruby
signature.match(/^([^\[]*)\[(.*)\]$/)
@expected_resource_type = $1
@expected_resource_name = $2
```

The `$1`/`$2` globals are implicit, thread-local-but-easy-to-misuse state that's brittle if any other match runs in between. Capturing the `MatchData` in a local and reading `match[1]`/`match[2]` is clearer and self-contained, with identical behavior.

## Testing

- `bundle exec rspec spec/unit/matchers/subscribes_matcher_spec.rb spec/unit/matchers/notifications_matcher_spec.rb` → `7 examples, 0 failures`.
- `bundle exec rspec spec/unit/` → `162 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml` → no offenses.