### PR TITLE
Drop the logger < 1.6 dependency pin

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -28,7 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency "fauxhai-chef", ">= 9.3"
   s.add_dependency "rspec", "~> 3.0"
 
-  # this needs to be remedied before Ruby 3.3
-  s.add_dependency "logger", "< 1.6"
   s.add_development_dependency "cookstyle", "~> 8.4"
 end


### PR DESCRIPTION
## Summary

Removes the `s.add_dependency "logger", "< 1.6"` pin (and its stale "remedy before Ruby 3.3" comment).

## Background

The pin was added in July 2024 to avoid `logger` 1.6.0, which introduced thread-local log levels by adding state in `Logger#initialize`. That broke `Logger` subclasses (across the ecosystem — Rails/ActiveSupport, and Chef's `Mixlib::Log::Logger`) that overrode `initialize` without calling `super`. Expressed as `< 1.6`, the pin also blocks all of 1.6.x and 1.7.x.

Two reasons it's safe to drop now:
1. **ChefSpec doesn't use `logger` directly** — there is no `require "logger"` anywhere in `lib/`. It only arrives transitively through `chef`, which owns that compatibility concern.
2. **The modern Chef stack handles current `logger` fine.** Verified locally against **Chef 19.2.12 / Mixlib::Log 3.2.3** with **logger 1.7.0** forced: `require "chefspec"` succeeds, `Chef::Log` instantiates and logs, and the full unit suite passes `162 examples, 0 failures`.

## Testing

- `Gem::Specification.load("chefspec.gemspec").validate` → valid.
- Unit suite under logger 1.7.0 (local lib): `162 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml chefspec.gemspec` → no offenses.

## Note

Touches `chefspec.gemspec`, as do #31 (removes the dangling rspec-expectations comment) and #40 (adds the `metadata` block). All three edit different lines and should merge cleanly.