### PR TITLE
Fix NaN coverage percentage when no resources are collected

### DIFF
--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -161,7 +161,7 @@ module ChefSpec
       report = {}.tap do |h|
         h[:total]     = @collection.size
         h[:touched]   = @collection.count { |_, resource| resource.touched? }
-        h[:coverage]  = ((h[:touched] / h[:total].to_f) * 100).round(2)
+        h[:coverage]  = coverage_percentage(h[:touched], h[:total])
       end
 
       report[:untouched_resources] = @collection.collect do |_, resource|
@@ -178,6 +178,18 @@ module ChefSpec
     end
 
     private
+
+    #
+    # The percentage of covered resources, guarding against a division by zero
+    # when no resources were collected (which would otherwise produce NaN).
+    #
+    # @return [Float]
+    #
+    def coverage_percentage(touched, total)
+      return 0.0 if total == 0
+
+      ((touched / total.to_f) * 100).round(2)
+    end
 
     def find(resource)
       @collection[resource.to_s]

--- a/spec/unit/coverage_spec.rb
+++ b/spec/unit/coverage_spec.rb
@@ -56,3 +56,23 @@ describe ChefSpec::Coverage::ResourceWrapper do
     end
   end
 end
+
+describe ChefSpec::Coverage do
+  subject(:coverage) { described_class.instance }
+
+  describe "#coverage_percentage" do
+    it "returns 0.0 when there are no resources instead of NaN" do
+      result = coverage.send(:coverage_percentage, 0, 0)
+      expect(result).to eq(0.0)
+      expect(result).not_to be_nan
+    end
+
+    it "calculates the touched percentage" do
+      expect(coverage.send(:coverage_percentage, 3, 4)).to eq(75.0)
+    end
+
+    it "rounds to two decimal places" do
+      expect(coverage.send(:coverage_percentage, 1, 3)).to eq(33.33)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`ChefSpec::Coverage#report!` computed the coverage percentage as:

```ruby
h[:coverage] = ((h[:touched] / h[:total].to_f) * 100).round(2)
```

When a run collects **no resources** (`total == 0`), that's `0 / 0.0`, which evaluates to `NaN`. The bundled human ERB template guards display with `if @total == 0`, so it's invisible there — but the `NaN` still lands in the `report` hash and is handed to every registered output, including JSON and any programmatic consumer.

## Fix

Extract the calculation into a private `coverage_percentage(touched, total)` helper that returns `0.0` when there are no resources, and use it in `report!`. `0.0` (rather than `100.0`) is the least-surprising value for "nothing was collected."

## Testing

- Added `spec/unit/coverage_spec.rb` (TDD — verified it failed first) covering the zero-resources case (`0.0`, not `NaN`), a normal percentage, and rounding.
- `bundle exec rspec spec/unit/` → `165 examples, 0 failures`.
- `cookstyle --chefstyle -c .rubocop.yml` → no offenses.

## Note

Adds `spec/unit/coverage_spec.rb`, which #44 also adds (there it covers `Coverage::ResourceWrapper`). Whichever merges first, the other just needs the two `describe` blocks combined into the one file.