### PR TITLE
Support matchers and regexps for the source property (#980)

### DIFF
--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -138,8 +138,12 @@ module ChefSpec::Matchers
     def matches_parameter?(parameter, expected)
       value = safe_send(parameter)
       if parameter == :source
-        # Chef 11+ stores the source parameter internally as an Array
-        Array(expected) == Array(value)
+        # Chef may store the source parameter internally as an Array. Match the
+        # expectation against the value directly first, so RSpec matchers and
+        # Regexps work against a scalar source, then fall back to comparing the
+        # array-normalized forms so a plain string still matches a single-element
+        # array source.
+        expected === value || Array(expected) == Array(value)
       elsif expected.is_a?(Class)
         # Ruby can't compare classes with ===
         expected == value

--- a/spec/unit/matchers/resource_matcher_spec.rb
+++ b/spec/unit/matchers/resource_matcher_spec.rb
@@ -37,4 +37,39 @@ describe ChefSpec::Matchers::ResourceMatcher do
       expect(subject).not_to respond_to(:nonexistent_method)
     end
   end
+
+  describe "matching the :source parameter" do
+    subject { described_class.new(:windows_certificate, :create, "CN=example.com") }
+
+    # `matches_parameter?` is the private comparison that `.with(source: ...)`
+    # relies on. Drive it directly with a stubbed resource value.
+    def source_matches?(expected, actual_source)
+      allow(subject).to receive(:resource).and_return(double(source: actual_source))
+      subject.send(:matches_parameter?, :source, expected)
+    end
+
+    it "matches an exact string source" do
+      expect(source_matches?("C:/MyFile.pem", "C:/MyFile.pem")).to be(true)
+    end
+
+    it "matches a plain string against an array-valued source" do
+      expect(source_matches?("foo.erb", ["foo.erb"])).to be(true)
+    end
+
+    it "matches an exact array source" do
+      expect(source_matches?(%w{a b}, %w{a b})).to be(true)
+    end
+
+    it "matches an RSpec matcher against a scalar source (issue #980)" do
+      expect(source_matches?(end_with("MyFile.pem"), "C:/MyFile.pem")).to be(true)
+    end
+
+    it "matches a Regexp against a scalar source" do
+      expect(source_matches?(/MyFile\.pem/, "C:/MyFile.pem")).to be(true)
+    end
+
+    it "does not match when the matcher does not apply" do
+      expect(source_matches?(end_with("other.pem"), "C:/MyFile.pem")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes chefspec/chefspec#980 — `.with(source: <matcher>)` never matches.

`ResourceMatcher#matches_parameter?` special-cases the `source` property:

```ruby
if parameter == :source
  # Chef 11+ stores the source parameter internally as an Array
  Array(expected) == Array(value)
```

The intent is to let a plain string match a source that Chef stored as an Array. But wrapping the *expectation* in an Array and comparing with `==` means an RSpec matcher or Regexp can never match. For the reporter's case:

```ruby
.with(source: end_with('MyFile.pem'))   # value is "C:/MyFile.pem"
# becomes: [#<EndWith ...>] == ["C:/MyFile.pem"]  => always false
```

Every other property routes through `expected === value`, which is exactly what makes matchers/Regexps work — `source` was the one exception.

## Fix

Try `expected === value` first (so RSpec matchers, Regexps, and exact scalar/array values all work), then fall back to the array-normalized `Array(expected) == Array(value)` so a plain string still matches a single-element array source — preserving the original behavior.

```ruby
expected === value || Array(expected) == Array(value)
```

## Testing

- Added unit specs for `:source` matching (TDD — the matcher and Regexp cases failed first): exact string, plain-string-vs-array, exact array, an RSpec matcher against a scalar source (the issue), a Regexp, and a non-matching matcher (stays false — no over-matching).
- `bundle exec rspec spec/unit/` → `167 examples, 0 failures`.
- Acceptance examples for the real source-using resources (`cookbook_file`, `remote_file`, `template`, `render_file`) → `116 examples, 0 failures` (array-source path unregressed).
- `cookstyle --chefstyle -c .rubocop.yml` → no offenses.

## Note

Touches `spec/unit/matchers/resource_matcher_spec.rb`, which is also rewritten by #31 and #42. Whichever merges first, the others need their `describe` blocks combined into the one file.