### PR TITLE
Render the creating resource when a path has several resources

### DIFF
--- a/examples/render_file/recipes/default.rb
+++ b/examples/render_file/recipes/default.rb
@@ -13,3 +13,13 @@ end
 template '/tmp/partial' do
   source 'partial.erb'
 end
+
+# A template and a file resource for the same path, as produced by a recipe
+# that either renders or removes a config file depending on an attribute.
+template '/tmp/template_or_delete' do
+  source 'template.erb'
+end
+
+file '/tmp/template_or_delete' do
+  action :delete
+end

--- a/examples/render_file/spec/default_spec.rb
+++ b/examples/render_file/spec/default_spec.rb
@@ -195,4 +195,11 @@ describe 'render_file::default' do
       it { is_expected.to_not render_file('/tmp/partial').with_content(/^Not(.+)$/) }
     end
   end
+
+  context 'a path with both a template and a file resource' do
+    describe 'renders the template rather than matching the delete' do
+      it { is_expected.to render_file('/tmp/template_or_delete') }
+      it { is_expected.to render_file('/tmp/template_or_delete').with_content('This is content!') }
+    end
+  end
 end

--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -86,9 +86,18 @@ module ChefSpec::Matchers
     end
 
     def resource
-      @resource ||= @runner.find_resource(:cookbook_file, @path) ||
-        @runner.find_resource(:file, @path) ||
-        @runner.find_resource(:template, @path)
+      return @resource if defined?(@resource)
+
+      candidates = %i{cookbook_file file template}.filter_map do |type|
+        @runner.find_resource(type, @path)
+      end
+
+      # A recipe may declare more than one resource for the same path, most
+      # commonly a template that creates the file and a file resource that
+      # deletes it, with guards selecting between them. Prefer whichever
+      # resource actually creates the file so that we do not report the file as
+      # unrendered just because a sibling delete resource was found first.
+      @resource = candidates.find { |candidate| create_action?(candidate) } || candidates.first
     end
 
     #
@@ -99,6 +108,17 @@ module ChefSpec::Matchers
     # @return [true, false]
     #
     def has_create_action?
+      create_action?(resource)
+    end
+
+    #
+    # Determines if the given resource has a create-like action.
+    #
+    # @param [Chef::Resource] resource
+    #
+    # @return [true, false]
+    #
+    def create_action?(resource)
       %i{create create_if_missing}.any? { |action| resource.performed_action?(action) }
     end
 


### PR DESCRIPTION
Fixes chefspec/chefspec#858

## Problem

`render_file` resolved the resource for a path like this:

```ruby
@resource ||= @runner.find_resource(:cookbook_file, @path) ||
  @runner.find_resource(:file, @path) ||
  @runner.find_resource(:template, @path)
```

It stops at the first match and never considers the action. A recipe that renders a config file with a template and removes it with a guarded `file` resource declares two resources for the same path, so the `file[:delete]` resource wins and `render_file` reports the file as unrendered.

The confusing part is that `create_template` matches correctly at the same time, which makes this look like a rendering bug rather than a lookup bug.

```ruby
template '/tmp/thing' do
  source 'thing.erb'
end

file '/tmp/thing' do
  action :delete
end
```

```
expected Chef run to render "/tmp/thing"
```

## Fix

Collect all candidate resources for the path and prefer whichever one performs a create-like action, falling back to the first match so failure messages are unchanged when nothing creates the file.

## Testing

Adds a template plus `file[:delete]` pair for the same path to the `render_file` acceptance example.

- With the fix: `55 examples, 0 failures`
- With the fix reverted: `55 examples, 2 failures`
- Unit suite: `197 examples, 0 failures`
- All acceptance examples pass
