### PR TITLE
Support RSpec matchers when matching the source attribute

### DIFF
--- a/examples/template/recipes/create.rb
+++ b/examples/template/recipes/create.rb
@@ -13,3 +13,7 @@ end
 template 'specifying the identity attribute' do
   path '/tmp/identity_attribute'
 end
+
+template '/tmp/with_source' do
+  source 'with_source.erb'
+end

--- a/examples/template/spec/create_spec.rb
+++ b/examples/template/spec/create_spec.rb
@@ -33,4 +33,12 @@ describe 'template::create' do
   describe 'creates a template when specifying the identity attribute' do
     it { is_expected.to create_template('/tmp/identity_attribute') }
   end
+
+  describe 'matches the source attribute' do
+    it { is_expected.to create_template('/tmp/with_source').with(source: 'with_source.erb') }
+
+    it { is_expected.to create_template('/tmp/with_source').with(source: end_with('source.erb')) }
+    it { is_expected.to create_template('/tmp/with_source').with(source: match(/with_\w+\.erb/)) }
+    it { is_expected.to_not create_template('/tmp/with_source').with(source: end_with('other.erb')) }
+  end
 end

--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -137,8 +137,10 @@ module ChefSpec::Matchers
 
     def matches_parameter?(parameter, expected)
       value = safe_send(parameter)
-      if parameter == :source
-        # Chef 11+ stores the source parameter internally as an Array
+      if parameter == :source && !RSpec::Matchers.is_a_matcher?(expected)
+        # Chef 11+ stores the source parameter internally as an Array. Skip the
+        # coercion for RSpec matchers, which need to be handed the value itself
+        # rather than being wrapped in an Array and compared for equality.
         Array(expected) == Array(value)
       elsif expected.is_a?(Class)
         # Ruby can't compare classes with ===


### PR DESCRIPTION
Fixes chefspec/chefspec#980

## Problem

`matches_parameter?` special cases `source` because Chef stores it internally as an Array:

```ruby
if parameter == :source
  # Chef 11+ stores the source parameter internally as an Array
  Array(expected) == Array(value)
```

That branch also catches RSpec matchers. An `end_with('.erb')` matcher gets wrapped in an Array and compared with `==` against `["thing.erb"]`, which is never true, so composable matchers silently never match `source`.

They work on every other attribute, which makes this look like the value is wrong rather than the comparison:

```ruby
# passes
is_expected.to create_template('/tmp/other').with(path: end_with('other'))

# fails
is_expected.to create_template('/tmp/other').with(source: end_with('.erb'))
```

```
source #<RSpec::Matchers::BuiltIn::EndWith ... @expected=".erb">, was "thing.erb"
```

## Fix

Skip the Array coercion when the expected value is an RSpec matcher, so the matcher is handed the value itself. Plain strings and arrays keep the existing coercion.

## Testing

Adds string, `end_with`, `match` and negative cases for `source` to the `template` acceptance example.

- With the fix: `25 examples, 0 failures`
- With the fix reverted: `25 examples, 2 failures`
- `cookbook_file`, `remote_file` and `file` examples still pass, covering the Array coercion path
- Unit suite: `197 examples, 0 failures`
