### PR TITLE
Expose Chef's template helper variables when rendering

### DIFF
--- a/examples/render_file/recipes/template_helpers.rb
+++ b/examples/render_file/recipes/template_helpers.rb
@@ -7,3 +7,7 @@ end
 template '/tmp/template_with_helper' do
   helpers TestHelper
 end
+
+template '/tmp/template_with_variables' do
+  source 'template_with_variables.erb'
+end

--- a/examples/render_file/spec/template_helpers_spec.rb
+++ b/examples/render_file/spec/template_helpers_spec.rb
@@ -9,4 +9,21 @@ describe 'render_file::template_helpers' do
         .with_content(/^helper result: hello$/)
     }
   end
+
+  describe 'renders the file using Chef\'s template helper variables' do
+    it {
+      is_expected.to render_file('/tmp/template_with_variables')
+        .with_content(/^cookbook: render_file$/)
+    }
+
+    it {
+      is_expected.to render_file('/tmp/template_with_variables')
+        .with_content(/^template: template_with_variables\.erb$/)
+    }
+
+    it {
+      is_expected.to render_file('/tmp/template_with_variables')
+        .with_content(/^recipe: template_helpers$/)
+    }
+  end
 end

--- a/examples/render_file/templates/default/template_with_variables.erb
+++ b/examples/render_file/templates/default/template_with_variables.erb
@@ -1,0 +1,3 @@
+cookbook: <%= cookbook_name %>
+template: <%= template_name %>
+recipe: <%= recipe_name %>

--- a/lib/chefspec/renderer.rb
+++ b/lib/chefspec/renderer.rb
@@ -96,6 +96,23 @@ module ChefSpec
           node: chef_run.node,
           template_finder: template_finder(chef_run, cookbook_name),
         }.merge(variables))
+        # Chef's template provider exposes a handful of helper variables to
+        # every template, so templates that reference them render empty under
+        # ChefSpec unless we do the same. See
+        # Chef::Provider::Template::Content#file_for_provider. Variables set on
+        # the resource take precedence.
+        {
+          cookbook_name: template.cookbook_name,
+          recipe_name: template.recipe_name,
+          recipe_line_string: template.source_line,
+          recipe_path: template.source_line_file,
+          recipe_line: template.source_line_number,
+          template_name: template.source,
+          template_path: template_location,
+        }.each do |key, value|
+          template_context[key] = value unless template_context.keys.include?(key)
+        end
+
         if template.respond_to?(:helper_modules) # Chef 11.4+
           template_context._extend_modules(template.helper_modules)
         end

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -10,7 +10,18 @@ describe ChefSpec::Renderer do
   end
 
   let(:chef_run) { double("chef_run", { node: "node" }) }
-  let(:resource) { double("resource", { cookbook: "cookbook", source: "source", variables: { x: "y", foo: Chef::DelayedEvaluator.new { "bar" } } }) }
+  let(:resource) do
+    double("resource", {
+      cookbook: "cookbook",
+      source: "source",
+      variables: { x: "y", foo: Chef::DelayedEvaluator.new { "bar" } },
+      cookbook_name: "cookbook",
+      recipe_name: "default",
+      source_line: "/recipes/default.rb:1:in `from_file'",
+      source_line_file: "/recipes/default.rb",
+      source_line_number: "1",
+    })
+  end
   subject { described_class.new(chef_run, resource) }
 
   describe "#content" do
@@ -59,7 +70,7 @@ describe ChefSpec::Renderer do
       allow(resource).to receive(:helper_modules).and_return([Module.new])
       allow(resource).to receive(:resource_name).and_return("template")
 
-      chef_template_context = double("context", { render_template: "rendered template content", update: nil })
+      chef_template_context = double("context", { render_template: "rendered template content", update: nil, keys: [], :[]= => nil })
       allow(Chef::Mixin::Template::TemplateContext).to receive(:new).and_return(chef_template_context)
 
       expect(chef_template_context).to receive(:_extend_modules).with(resource.helper_modules)


### PR DESCRIPTION
Fixes chefspec/chefspec#795

## Problem

Chef's template provider sets helper variables on the template context before rendering, in `Chef::Provider::Template::Content#file_for_provider`:

```ruby
context[:cookbook_name] = new_resource.cookbook_name unless context.keys.include?(:cookbook_name)
context[:recipe_name] = new_resource.recipe_name unless context.keys.include?(:recipe_name)
context[:recipe_line_string] = new_resource.source_line unless context.keys.include?(:recipe_line_string)
context[:recipe_path] = new_resource.source_line_file unless context.keys.include?(:recipe_path)
context[:recipe_line] = new_resource.source_line_number unless context.keys.include?(:recipe_line)
context[:template_name] = new_resource.source unless context.keys.include?(:template_name)
context[:template_path] = template_location unless context.keys.include?(:template_path)
```

ChefSpec's renderer only sets `node` and `template_finder`, so a template containing `<%= cookbook_name %>` renders an empty string under test while working correctly during a real Chef run:

```
expected Chef run to render "/tmp/cbname" matching:
I am from the repro cookbook
but got:
I am from the  cookbook
```

## Fix

Set the same helper variables Chef does, keeping Chef's rule that variables supplied on the resource take precedence.

## Testing

Adds a template referencing `cookbook_name`, `template_name` and `recipe_name` to the `render_file` acceptance example.

- With the fix: `56 examples, 0 failures`
- With the fix reverted: `56 examples, 3 failures`
- Unit suite: `197 examples, 0 failures`

The `resource` double in `spec/unit/renderer_spec.rb` is extended with the attributes the renderer now reads.
