### PR TITLE
Ignore gem options when resolving cookbook gem metadata

### DIFF
--- a/examples/cookbook_gems/metadata.rb
+++ b/examples/cookbook_gems/metadata.rb
@@ -1,0 +1,6 @@
+name 'cookbook_gems'
+version '1.0.0'
+
+# Gem declarations accept the same trailing options Hash a Gemfile does.
+gem 'rspec'
+gem 'chef-utils', platforms: %i{mingw mswin x64_mingw}

--- a/examples/cookbook_gems/recipes/default.rb
+++ b/examples/cookbook_gems/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'cookbook_gems'

--- a/examples/cookbook_gems/spec/default_spec.rb
+++ b/examples/cookbook_gems/spec/default_spec.rb
@@ -1,0 +1,10 @@
+require 'chefspec'
+
+describe 'cookbook_gems::default' do
+  platform 'ubuntu'
+
+  describe 'converges a cookbook whose gem metadata carries options' do
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to write_log('cookbook_gems') }
+  end
+end

--- a/lib/chefspec/extensions/chef/cookbook/gem_installer.rb
+++ b/lib/chefspec/extensions/chef/cookbook/gem_installer.rb
@@ -21,7 +21,16 @@ Chef::Cookbook::GemInstaller.prepend(Module.new do
   private
 
   def locate_gem(gem_name, gem_requirements)
-    ::Gem::Specification.find_by_name(gem_name, gem_requirements)
+    # A cookbook's gem metadata takes the same trailing options Hash a Gemfile
+    # does, for example:
+    #
+    #   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+    #
+    # Chef hands those straight to a generated Gemfile, but they are not
+    # version requirements, so drop them before asking Rubygems to resolve the
+    # gem or Gem::Requirement raises BadRequirementError.
+    gem_requirements = gem_requirements.grep_v(Hash)
+    ::Gem::Specification.find_by_name(gem_name, *gem_requirements)
   rescue ::Gem::MissingSpecError
     gem_cmd = "gem install #{gem_name} --version '#{gem_requirements.join(", ")}'"
     gemfile_line = "gem '#{[gem_name, *gem_requirements].join("', '")}'"


### PR DESCRIPTION
Fixes chefspec/chefspec#1016

## Problem

A cookbook's gem metadata accepts the same trailing options Hash a Gemfile does:

```ruby
gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
```

`Chef::Cookbook::Metadata#gem` stores the raw args, and Chef writes them into a generated Gemfile where `gem(*args)` handles the Hash natively. ChefSpec's override instead passes them to `Gem::Specification.find_by_name` as version requirements:

```ruby
::Gem::Specification.find_by_name(gem_name, gem_requirements)
```

`Gem::Requirement` then raises `BadRequirementError`, which the `rescue ::Gem::MissingSpecError` does not catch, so the whole converge fails:

```
Gem::Requirement::BadRequirementError:
  Illformed requirement [{platforms: [:mingw, :mswin, :x64_mingw]}]
# lib/chefspec/extensions/chef/cookbook/gem_installer.rb:24:in 'locate_gem'
```

This also fires for a dependent cookbook's metadata, so it can break a run for a cookbook the author does not control.

## Fix

Drop the options Hash before resolving, keeping only the version requirements.

## Testing

Adds a `cookbook_gems` acceptance example whose `metadata.rb` declares gems both with and without an options Hash.

- With the fix: `2 examples, 0 failures`
- With the fix reverted: `2 examples, 2 failures` (`BadRequirementError`)
- Unit suite: `197 examples, 0 failures`

Worth noting separately: a gem restricted to platforms that do not match the current one now falls through to the existing "No matching version found" warning (chefspec/chefspec#1015). Skipping non-matching platforms outright would be a reasonable follow-up.
