### PR TITLE
Honor the globally configured platform in example groups

### DIFF
--- a/examples/spec_global_platform/recipes/default.rb
+++ b/examples/spec_global_platform/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'default'

--- a/examples/spec_global_platform/resources/greet.rb
+++ b/examples/spec_global_platform/resources/greet.rb
@@ -1,0 +1,7 @@
+provides :spec_global_platform_greet
+
+property :message, String, default: 'Hello world'
+
+action :run do
+  log new_resource.message
+end

--- a/examples/spec_global_platform/spec/default_spec.rb
+++ b/examples/spec_global_platform/spec/default_spec.rb
@@ -1,0 +1,28 @@
+require 'chefspec'
+
+# The platform can be set globally rather than per example group, which is how
+# a lot of existing cookbooks configure it from spec_helper.rb.
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '20.04'
+end
+
+describe 'spec_global_platform_greet' do
+  step_into :spec_global_platform_greet
+
+  context 'with the default greeting' do
+    recipe do
+      spec_global_platform_greet 'test'
+    end
+
+    it { is_expected.to write_log('Hello world') }
+  end
+
+  context 'with an explicit greeting' do
+    recipe do
+      spec_global_platform_greet('test') { message 'Hello there' }
+    end
+
+    it { is_expected.to write_log('Hello there') }
+  end
+end

--- a/lib/chefspec/api/core.rb
+++ b/lib/chefspec/api/core.rb
@@ -31,8 +31,8 @@ module ChefSpec
       let(:chefspec_normal_attributes) { chefspec_attributes(:normal_attributes) }
       let(:chefspec_override_attributes) { chefspec_attributes(:override_attributes) }
       let(:chefspec_automatic_attributes) { chefspec_attributes(:automatic_attributes) }
-      let(:chefspec_platform) { nil }
-      let(:chefspec_platform_version) { nil }
+      let(:chefspec_platform) { RSpec.configuration.platform }
+      let(:chefspec_platform_version) { RSpec.configuration.version }
 
       # Compute the options for the runner.
       #


### PR DESCRIPTION
Fixes chefspec/chefspec#953

## Problem

The platform can be set globally instead of per example group, which is how a lot of existing cookbooks configure it from `spec_helper.rb`:

```ruby
RSpec.configure do |config|
  config.platform = 'ubuntu'
  config.version = '20.04'
end
```

`SoloRunner#with_default_options` already falls back to that setting, but the example group helpers did not:

```ruby
let(:chefspec_platform) { nil }
let(:chefspec_platform_version) { nil }
```

Both the preload and the `Chef.node` stub are gated on `chefspec_platform`:

```ruby
chef_runner_instance.preload! if chefspec_platform
...
allow(::Chef).to receive(:node).and_return(chef_node) if chefspec_platform
```

So with only the global setting, custom resources are never registered and referencing one from a `recipe` block raises:

```
NoMethodError:
  undefined method 'mycookbook_greet' for an instance of Chef::Recipe
```

Built in resources keep working, which is what makes this hard to diagnose. Adding `platform 'ubuntu'` to the describe block fixes it, and several people in the issue report losing hours to it.

## Fix

Default the platform and version lets to the global configuration, so the example group helpers agree with the runner.

## Testing

Adds a `spec_global_platform` acceptance example: a custom resource, a global `RSpec.configure` platform, and no per example group `platform`.

- With the fix: `2 examples, 0 failures`
- With the fix reverted: `2 examples, 2 failures` (`NoMethodError`)
- Unit suite: `197 examples, 0 failures`
- All acceptance examples pass, including `spec_platform`, which covers the no-platform warning path

This does not address the related wrinkle in the issue thread where a global `version` combines with a per example group `platform` (`ubuntu/7.8`). That is a separate bug.
