### PR TITLE
Start the chef-zero server on demand

### DIFF
--- a/examples/no_server/recipes/default.rb
+++ b/examples/no_server/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'no_server'

--- a/examples/no_server/spec/default_spec.rb
+++ b/examples/no_server/spec/default_spec.rb
@@ -1,0 +1,11 @@
+require 'chefspec'
+
+describe 'no_server::default' do
+  platform 'ubuntu'
+
+  it { is_expected.to write_log('no_server') }
+
+  it 'does not start a chef-zero server' do
+    expect(ChefSpec::ZeroServer.server).to_not be_running
+  end
+end

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -10,6 +10,7 @@ module ChefSpec
     # @return [ChefZero::Server]
     #
     def server
+      ChefSpec::ZeroServer.setup!
       ChefSpec::ZeroServer.server
     end
 

--- a/lib/chefspec/zero_server.rb
+++ b/lib/chefspec/zero_server.rb
@@ -29,6 +29,10 @@ module ChefSpec
     # Remove all the data we just loaded from the ChefZero server
     #
     def reset!
+      # Nothing to reset when the server was never started, which is the case
+      # for any suite that only uses the SoloRunner.
+      return unless @server.running?
+
       if RSpec.configuration.server_runner_clear_cookbooks
         @server.clear_data
         @cookbooks_uploaded = false
@@ -75,6 +79,8 @@ module ChefSpec
     def upload_cookbooks!
       return if @cookbooks_uploaded
 
+      setup!
+
       loader = Chef::CookbookLoader.new(Chef::Config[:cookbook_path])
       loader.load_cookbooks
       cookbook_uploader_for(loader).upload_cookbooks
@@ -93,6 +99,8 @@ module ChefSpec
     #   to the server
     #
     def load_data(name, key, data)
+      setup!
+
       @data_loaded[key] ||= []
       @data_loaded[key] << name
       @server.load_data({ key => { name => data } })
@@ -136,7 +144,9 @@ module ChefSpec
 end
 
 RSpec.configure do |config|
-  config.before(:suite) { ChefSpec::ZeroServer.setup! }
+  # The server is started on demand rather than for every suite, so that suites
+  # which only use the SoloRunner do not occupy a port from the configured
+  # range. See the ZeroServer.setup! callers.
   config.after(:each) { ChefSpec::ZeroServer.reset! }
   config.after(:suite)  { ChefSpec::ZeroServer.teardown! }
 end


### PR DESCRIPTION
Fixes chefspec/chefspec#1017

## Problem

Requiring chefspec pulls in `ServerRunner`, which pulls in `ZeroServer`, which registers:

```ruby
RSpec.configure do |config|
  config.before(:suite) { ChefSpec::ZeroServer.setup! }
  config.after(:each) { ChefSpec::ZeroServer.reset! }
```

A chef-zero server therefore starts for every suite, including suites that only ever use the `SoloRunner`. That reserves one port from `server_runner_port` (default `8889..8899`) for the whole run, so no more than 11 suites can run concurrently before they fail to find a free port. It also runs a data reset after every single example.

Measured on a suite that only uses `platform` and `SoloRunner`, before the change:

```
PID 98098 sees open ports: [8889, 8890]
PID 98100 sees open ports: [8889, 8890]
```

## Fix

Start the server the first time something actually needs it, from `upload_cookbooks!`, `load_data` and the `server` accessor, and skip the per example reset while it is not running.

This is the third option the reporter suggested. It is not a breaking change: `ServerRunner` behavior is unchanged, and code that starts the server explicitly, as `examples/server/spec/exotic_port_spec.rb` does, still works.

## Testing

Adds a `no_server` acceptance example asserting no chef-zero server is running for a `SoloRunner` only suite.

- With the fix: `2 examples, 0 failures`, and no ports bound
- With the fix reverted: `2 examples, 1 failure`
- `server` acceptance example (all `ServerRunner`): `17 examples, 0 failures`
- Unit suite: `197 examples, 0 failures`
