### PR TITLE
Do not report notifications from guard skipped resources

### DIFF
--- a/examples/notifications/recipes/guarded.rb
+++ b/examples/notifications/recipes/guarded.rb
@@ -1,0 +1,18 @@
+execute 'reload' do
+  command 'true'
+  action :nothing
+end
+
+# The guard stops the action from running, so Chef never delivers the
+# notification.
+file '/tmp/guarded' do
+  action :delete
+  notifies :run, 'execute[reload]', :immediately
+  only_if { 1 == 2 }
+end
+
+# An unguarded resource for comparison.
+file '/tmp/unguarded' do
+  action :delete
+  notifies :run, 'execute[reload]', :immediately
+end

--- a/examples/notifications/spec/guarded_spec.rb
+++ b/examples/notifications/spec/guarded_spec.rb
@@ -1,0 +1,20 @@
+require 'chefspec'
+
+describe 'notifications::guarded' do
+  platform 'ubuntu'
+
+  let(:guarded)   { chef_run.file('/tmp/guarded') }
+  let(:unguarded) { chef_run.file('/tmp/unguarded') }
+
+  it 'does not run the guarded resource' do
+    expect(chef_run).to_not delete_file('/tmp/guarded')
+  end
+
+  it 'does not notify from a resource a guard skipped' do
+    expect(guarded).to_not notify('execute[reload]').to(:run).immediately
+  end
+
+  it 'still notifies from a resource that ran' do
+    expect(unguarded).to notify('execute[reload]').to(:run).immediately
+  end
+end

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -49,7 +49,13 @@ module ChefSpec::Extensions::Chef::Resource
 
     ChefSpec::Coverage.add(self)
 
-    unless should_skip?(action)
+    if should_skip?(action)
+      # should_skip? is also true for `action :nothing`, via Chef's
+      # ConditionalActionNotNothing, which is not a guard refusing to run the
+      # resource. Only record real guard skips so that matchers can tell the
+      # two apart.
+      perform_skipped_action(action) unless action.to_sym == :nothing
+    else
       if node.runner.step_into?(self)
         instance_eval { @not_if = []; @only_if = [] }
         super
@@ -89,6 +95,20 @@ module ChefSpec::Extensions::Chef::Resource
   def performed_actions
     @performed_actions ||= {}
     @performed_actions.keys
+  end
+
+  def perform_skipped_action(action)
+    @skipped_actions ||= []
+    @skipped_actions |= [action.to_sym]
+  end
+
+  #
+  # The actions that did not run because a guard refused them.
+  #
+  # @return [Array<Symbol>]
+  #
+  def skipped_actions
+    @skipped_actions ||= []
   end
 
   #

--- a/lib/chefspec/matchers/notifications_matcher.rb
+++ b/lib/chefspec/matchers/notifications_matcher.rb
@@ -12,6 +12,12 @@ module ChefSpec::Matchers
       @resource = resource
 
       if @resource
+        # Notifications stay declared on a resource even when a guard stopped
+        # its action from running, but Chef only delivers them when the action
+        # actually runs. This deliberately does not cover `action :nothing`
+        # resources, which still notify when they are themselves notified.
+        return false if @resource.performed_actions.empty? && @resource.skipped_actions.any?
+
         block = proc do |notified|
           resource_name(notified.resource).to_s == @expected_resource_type &&
             (@expected_resource_name === notified.resource.identity.to_s || @expected_resource_name === notified.resource.name.to_s) &&

--- a/spec/unit/matchers/notifications_matcher_spec.rb
+++ b/spec/unit/matchers/notifications_matcher_spec.rb
@@ -8,6 +8,7 @@ describe ChefSpec::Matchers::NotificationsMatcher do
       to_s: "package[foo]",
       is_a?: true,
       performed_action?: true,
+      performed_actions: [:install],
       immediate_notifications: [],
       delayed_notifications: [],
       before_notifications: [])

--- a/spec/unit/matchers/subscribes_matcher_spec.rb
+++ b/spec/unit/matchers/subscribes_matcher_spec.rb
@@ -27,6 +27,7 @@ describe ChefSpec::Matchers::SubscribesMatcher do
       double("execute",
         name: "execute",
         to_s: "execute[install]",
+        performed_actions: [:run],
         immediate_notifications: [],
         delayed_notifications: [],
         before_notifications: [])


### PR DESCRIPTION
Fixes chefspec/chefspec#863
Fixes chefspec/chefspec#751

## Problem

Notifications stay declared on a resource even when a guard stopped its action from running, and the notify matcher reads that declaration directly. So a resource whose `only_if` never passed is still reported as notifying:

```ruby
execute 'reload' do
  command 'true'
  action :nothing
end

file '/tmp/guarded' do
  action :delete
  notifies :run, 'execute[reload]', :immediately
  only_if { false }
end
```

```
expected "file[/tmp/guarded]" to not notify "execute[reload]", but it did.
```

This is an internal contradiction rather than a design tradeoff. In the same run ChefSpec correctly reports that the action was skipped and that the notified resource never ran:

```ruby
is_expected.to_not delete_file('/tmp/guarded')  # passes
is_expected.to_not run_execute('reload')        # passes
```

## Fix

The obvious fix, suppressing notifications when `performed_actions` is empty, is wrong. Chef's `ConditionalActionNotNothing` makes `should_skip?` true for `action :nothing` too, so a guard skipped resource and a notified `action :nothing` resource look identical. That naive version breaks legitimate chained notifications and fails the existing `notifications::chained` and `subscribes` examples.

Instead, record genuine guard skips separately in `run_action` and only suppress notifications when the resource ran nothing *and* a guard refused it.

## Compatibility

This is the one behavior change in the set. A test that asserts a guarded resource notifies passes today and will start failing. That assertion was asserting something Chef does not do, but it is still visible breakage, so it is worth a changelog note.

## Testing

Adds a `notifications::guarded` acceptance example covering a guarded resource and an unguarded one for comparison.

- With the fix: `14 examples, 0 failures`
- With the fix reverted: `14 examples, 1 failure`
- `notifications`, `subscribes` and `guards` examples all pass
- Unit suite: `197 examples, 0 failures`
