### PR TITLE
Exclude the Windows gemspec from the chef git source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0' ]
     name: Test with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,12 @@ if ENV["GEMFILE_MOD"]
   puts "GEMFILE_MOD: #{ENV["GEMFILE_MOD"]}"
   instance_eval(ENV["GEMFILE_MOD"])
 else
-  gem "chef", git: "https://github.com/chef/chef.git"
+  # chef's repo also ships chef-universal-mingw-ucrt.gemspec, which declares
+  # itself as "chef" for the mingw platform and adds the Windows only
+  # dependencies. Bundler loads every gemspec it finds in a git source, so
+  # without this glob those Windows gems end up in the resolution on every
+  # platform and the bundle cannot be installed on Linux or macOS.
+  gem "chef", git: "https://github.com/chef/chef.git", glob: "{chef,chef-*/chef-*}.gemspec"
   gem "ohai", git: "https://github.com/chef/ohai.git"
 end
 


### PR DESCRIPTION
## Problem

CI has been failing on every job (Ruby 3.1 through 3.4) since the last green scheduled run. Both `rake unit` and `rake acceptance` fail before running anything:

```
bundler: failed to load command: rake
Could not find chef-cli-6.1.34, win32-api-1.10.1 in locally installed gems (Bundler::GemNotFound)
```

## Cause

chef's repo ships `chef-universal-mingw-ucrt.gemspec` next to `chef.gemspec`. It loads `chef.gemspec`, switches the platform, and adds the Windows only dependencies, but it keeps the gem name `chef`:

```ruby
gemspec = Gem::Specification.load(File.expand_path("chef.gemspec", __dir__))
gemspec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
gemspec.add_dependency "win32-api", "~> 1.10.0"
...
gemspec.add_dependency "chef-powershell", "~> 18.6.6"
```

Bundler loads every gemspec it finds in a git source (default glob `{,*,*/*}.gemspec`), so it picks up the mingw variant too. The resulting lockfile lists the Windows gems as dependencies of `chef` on every platform:

```
    chef (19.4.14)
      ...
      win32-api (~> 1.10.0)
      win32-certstore (~> 0.6.15)
      win32-eventlog (= 0.6.7)
```

Those gems cannot install on Linux or macOS, so the bundle is never fully installed and `bundle exec` fails. This is reproducible locally on a clean checkout, and it is why `bundle install` appears to succeed while `bundle check` still reports missing gems.

Nothing changed in this repo to trigger it, which is why it started failing on an unrelated push.

## Fix

Restrict the git source glob so the mingw variant is skipped:

```ruby
gem "chef", git: "https://github.com/chef/chef.git", glob: "{chef,chef-*/chef-*}.gemspec"
```

That still matches the gemspecs the resolution needs from the checkout:

```
chef.gemspec
chef-bin/chef-bin.gemspec
chef-config/chef-config.gemspec
chef-utils/chef-utils.gemspec
```

and leaves out `chef-universal-mingw-ucrt.gemspec`.

`ohai` is unaffected, its repo only has the one gemspec, so it is left alone.

## Testing

Verified on a clean `git archive` checkout of main, running the same commands CI runs:

- `bundle install` completes, and `bundle check` reports "The Gemfile's dependencies are satisfied"
- No `win32-*` or `chef-powershell` entries remain in the resolved lockfile
- `bundle exec rake unit` — `206 examples, 0 failures`, exit 0
- `bundle exec rake acceptance` — all example suites pass, exit 0

Without the change, the same checkout reproduces the CI failure exactly.

## Also in this PR

Adds Ruby 4.0 to the CI matrix, so the suite is covered on 3.1 through 4.0. Verified locally on Ruby 4.0.6: `rake unit` and `rake acceptance` both exit 0.
