### PR TITLE
Fix typos across comments, docs, and spec descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,7 +644,7 @@ Breaking:
 
 - `Runner#resources` converted from an Array to a Hash. This is to ensure that all resource actions are added (when multiple calls to run_action exist (#201)). This also drastically improves resource lookup times.
 
-- `Resource#actions` is no longer maniuplated. Instead, a new method `Resource#performed_actions` now keeps track of the actions taken on a resource (as well as the phase in which they were taken), preserving the original state of the resource.
+- `Resource#actions` is no longer manipulated. Instead, a new method `Resource#performed_actions` now keeps track of the actions taken on a resource (as well as the phase in which they were taken), preserving the original state of the resource.
 
 FEATURES:
 
@@ -713,7 +713,7 @@ BUG FIXES:
 - Better failure message for `create_remote_file` ([@tmatilai])
 - Add `cookbook_file` as an accepted type to the `create_file` matchers ([@dafyddcrosby])
 - Ensure formatter is only registered once ([@student])
-- Signifant README updates ([@phoolish])
+- Significant README updates ([@phoolish])
 - Fix `described_recipe` helper (S.R.Garcia)
 - Refactor Chef 10/11 template rendering ([@sethvargo])
 - Fix CI ([@sethvargo])

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ task :style do
   require "cookstyle/chefstyle"
 
   if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
-    # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaeded to GitHub.
+    # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaded to GitHub.
     # This is a workaround to ignore the CRLF from the files before running cookstyle.
     sh "cookstyle --chefstyle -c .rubocop.yml --except Layout/EndOfLine"
   else

--- a/examples/guards/spec/default_spec.rb
+++ b/examples/guards/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'chefspec'
 describe 'guards::default' do
   platform 'ubuntu'
 
-  describe 'includes resource that have guards that evalute to true' do
+  describe 'includes resource that have guards that evaluate to true' do
     it { is_expected.to start_service('true_guard') }
   end
 

--- a/examples/http_request/spec/options_spec.rb
+++ b/examples/http_request/spec/options_spec.rb
@@ -3,17 +3,17 @@ require 'chefspec'
 describe 'http_request::options' do
   platform 'ubuntu'
 
-  describe 'optionss a http_request with an explicit action' do
+  describe 'options a http_request with an explicit action' do
     it { is_expected.to options_http_request('explicit_action') }
     it { is_expected.to_not options_http_request('not_explicit_action') }
   end
 
-  describe 'optionss a http_request with attributes' do
+  describe 'options a http_request with attributes' do
     it { is_expected.to options_http_request('with_attributes').with(url: 'http://my.url') }
     it { is_expected.to_not options_http_request('with_attributes').with(url: 'http://my.other.url') }
   end
 
-  describe 'optionss a http_request when specifying the identity attribute' do
+  describe 'options a http_request when specifying the identity attribute' do
     it { is_expected.to options_http_request('identity_attribute') }
   end
 end

--- a/examples/notifications/spec/chained_spec.rb
+++ b/examples/notifications/spec/chained_spec.rb
@@ -14,7 +14,7 @@ describe 'notifications::chained' do
     expect(service).to notify('log[log]')
   end
 
-  it 'sends the specific notification to the serivce' do
+  it 'sends the specific notification to the service' do
     expect(template).to notify('service[service]').to(:restart)
     expect(template).to_not notify('service[service]').to(:stop)
   end

--- a/examples/notifications/spec/default_spec.rb
+++ b/examples/notifications/spec/default_spec.rb
@@ -9,7 +9,7 @@ describe 'notifications::default' do
     expect(template).to_not notify('service[not_receiving_resource]')
   end
 
-  it 'sends the specific notification to the serivce' do
+  it 'sends the specific notification to the service' do
     expect(template).to notify('service[receiving_resource]').to(:restart)
     expect(template).to_not notify('service[receiving_resource]').to(:stop)
   end

--- a/examples/notifications/spec/delayed_spec.rb
+++ b/examples/notifications/spec/delayed_spec.rb
@@ -9,7 +9,7 @@ describe 'notifications::delayed' do
     expect(template).to_not notify('service[not_receiving_resource]').delayed
   end
 
-  it 'sends the specific notification to the serivce delayed' do
+  it 'sends the specific notification to the service delayed' do
     expect(template).to notify('service[receiving_resource]').to(:restart).delayed
     expect(template).to_not notify('service[receiving_resource]').to(:restart).immediately
   end

--- a/examples/remote_file/spec/touch_spec.rb
+++ b/examples/remote_file/spec/touch_spec.rb
@@ -3,17 +3,17 @@ require 'chefspec'
 describe 'remote_file::touch' do
   platform 'ubuntu'
 
-  describe 'touchs a remote_file with an explicit action' do
+  describe 'touches a remote_file with an explicit action' do
     it { is_expected.to touch_remote_file('/tmp/explicit_action') }
     it { is_expected.to_not touch_remote_file('/tmp/not_explicit_action') }
   end
 
-  describe 'touchs a remote_file with attributes' do
+  describe 'touches a remote_file with attributes' do
     it { is_expected.to touch_remote_file('/tmp/with_attributes').with(owner: 'owner') }
     it { is_expected.to_not touch_remote_file('/tmp/with_attributes').with(owner: 'bacon') }
   end
 
-  describe 'touchs a remote_file when specifying the identity attribute' do
+  describe 'touches a remote_file when specifying the identity attribute' do
     it { is_expected.to touch_remote_file('/tmp/identity_attribute') }
   end
 end

--- a/examples/stubs_for/resources/old.rb
+++ b/examples/stubs_for/resources/old.rb
@@ -14,7 +14,7 @@ end
 action_class do
   def load_current_resource
     @current_resource = new_resource.class.new(new_resource.name)
-    # current_resource.shell_out is weird but mostly doing it for completeness and parity checking with load_curent_value-style.
+    # current_resource.shell_out is weird but mostly doing it for completeness and parity checking with load_current_value-style.
     @current_resource.value @current_resource.shell_out(new_resource.cmd).stdout if new_resource.run_load
     @current_resource
   end

--- a/examples/subscribes/spec/immediately_spec.rb
+++ b/examples/subscribes/spec/immediately_spec.rb
@@ -9,7 +9,7 @@ describe 'subscribes::immediately' do
     expect(service).to_not subscribe_to('template[/tmp/not_notifying_resource]').immediately
   end
 
-  it 'sends the specific notification to the serivce immediately' do
+  it 'sends the specific notification to the service immediately' do
     expect(service).to subscribe_to('template[/tmp/notifying_resource]').on(:create).immediately
     expect(service).to_not subscribe_to('template[/tmp/notifying_resource]').on(:delete).delayed
   end

--- a/lib/chefspec/api/render_file.rb
+++ b/lib/chefspec/api/render_file.rb
@@ -4,7 +4,7 @@ module ChefSpec
       #
       # Assert that a file is rendered by the Chef run. This matcher works for
       # +template+, +file+, and +cookbook_file+ resources. The content from the
-      # resource must be convertable to a string; verifying the content of a
+      # resource must be convertible to a string; verifying the content of a
       # binary file is not permissible at this time.
       #
       # @example Assert a template is rendered

--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -41,7 +41,7 @@ module ChefSpec
     end
 
     #
-    # Start the coverage reporting analysis. This method also adds the the
+    # Start the coverage reporting analysis. This method also adds the
     # +at_exit+ handler for printing the coverage report.
     #
     def start!(&block)
@@ -91,7 +91,7 @@ module ChefSpec
     end
 
     #
-    # Change the template for reporting of converage analysis.
+    # Change the template for reporting of coverage analysis.
     #
     # @param [string] path
     #   The template file to use for the output of the report

--- a/lib/chefspec/extensions/chef/securable.rb
+++ b/lib/chefspec/extensions/chef/securable.rb
@@ -5,7 +5,7 @@ class Chef
     module Securable
       # In Chef, this module is only included if the RUBY_PLATFORM is
       # Windows-like. In ChefSpec, we want to include this, regardless of the
-      # platform, becuase this module holds the `inherits` attribute, which is
+      # platform, because this module holds the `inherits` attribute, which is
       # critical in testing Windows resources.
       include WindowsSecurableAttributes
 

--- a/lib/chefspec/formatter.rb
+++ b/lib/chefspec/formatter.rb
@@ -170,7 +170,7 @@ module ChefSpec
       file_load_failed(path, exception)
     end
 
-    # Called when resource defintions are done loading
+    # Called when resource definitions are done loading
     def definition_load_complete; end
 
     # Called before recipes are loaded

--- a/lib/chefspec/renderer.rb
+++ b/lib/chefspec/renderer.rb
@@ -155,7 +155,7 @@ module ChefSpec
     # Return a new instance of the TemplateFinder if we are running on Chef 11.
     #
     # @param [Chef::RunContext] chef_run
-    #   the run context for the noe
+    #   the run context for the node
     # @param [String] cookbook_name
     #   the name of the cookbook
     #

--- a/spec/unit/macros_spec.rb
+++ b/spec/unit/macros_spec.rb
@@ -110,7 +110,7 @@ describe "nginx::source" do
       end
 
       context "in a nested context" do
-        it "still retrns the cookbook::recipe" do
+        it "still returns the cookbook::recipe" do
           expect(described_recipe).to eq("nginx::source")
         end
       end

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -50,7 +50,7 @@ describe ChefSpec::Renderer do
   end
 
   describe "content_from_template" do
-    it "renders the template by extending modules for rendering paritals within the template" do
+    it "renders the template by extending modules for rendering partials within the template" do
       cookbook_collection = {}
       cookbook_collection["cookbook"] = double("", { preferred_filename_on_disk_location: "/template/location" } )
       allow(subject).to receive(:cookbook_collection).with("node").and_return(cookbook_collection)
@@ -68,7 +68,7 @@ describe ChefSpec::Renderer do
   end
 
   describe "content_from_template with lazy/DelayedEvaluator" do
-    it "renders the template by extending modules for rendering paritals within the template" do
+    it "renders the template by extending modules for rendering partials within the template" do
       cookbook_collection = {}
       cookbook_collection["cookbook"] = double("", { preferred_filename_on_disk_location: "/template/location" } )
       allow(subject).to receive(:cookbook_collection).with("node").and_return(cookbook_collection)

--- a/spec/unit/stubs/data_bag_item_stub_spec.rb
+++ b/spec/unit/stubs/data_bag_item_stub_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ChefSpec::Stubs::DataBagItemStub do
-  it "inherts from Stub" do
+  it "inherits from Stub" do
     expect(described_class.superclass).to be(ChefSpec::Stubs::Stub)
   end
 

--- a/spec/unit/stubs/data_bag_stub_spec.rb
+++ b/spec/unit/stubs/data_bag_stub_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ChefSpec::Stubs::DataBagStub do
-  it "inherts from Stub" do
+  it "inherits from Stub" do
     expect(described_class.superclass).to be(ChefSpec::Stubs::Stub)
   end
 

--- a/spec/unit/stubs/search_stub_spec.rb
+++ b/spec/unit/stubs/search_stub_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ChefSpec::Stubs::SearchStub do
-  it "inherts from Stub" do
+  it "inherits from Stub" do
     expect(described_class.superclass).to be(ChefSpec::Stubs::Stub)
   end
 

--- a/templates/errors/erb_template_parse_error.erb
+++ b/templates/errors/erb_template_parse_error.erb
@@ -1,4 +1,4 @@
-An Error occured during parsing the Erb Given.
+An Error occurred during parsing the Erb Given.
 
 Here is the original error:
 


### PR DESCRIPTION
## Description

Fixes misspellings found by [`typos`](https://github.com/crate-ci/typos) plus one duplicated word (`adds the the`) caught by a separate backreference scan.

Every change is confined to a comment, an RSpec `describe`/`it` description string, the ERB parse-error template message, or CHANGELOG prose. No code, matcher names, resource names, or behavior are affected — the adjacent matcher calls (`touch_remote_file`, `options_http_request`) are untouched.

| Fix | Where |
| --- | --- |
| `uploaeded` → `uploaded` | `Rakefile` |
| `occured` → `occurred` | `templates/errors/erb_template_parse_error.erb` |
| `defintions` → `definitions` | `lib/chefspec/formatter.rb` |
| `converage` → `coverage`, `adds the the` → `adds the` | `lib/chefspec/coverage.rb` |
| `convertable` → `convertible` | `lib/chefspec/api/render_file.rb` |
| `noe` → `node` | `lib/chefspec/renderer.rb` |
| `becuase` → `because` | `lib/chefspec/extensions/chef/securable.rb` |
| `inherts` → `inherits` | 3 files under `spec/unit/stubs/` |
| `retrns` → `returns` | `spec/unit/macros_spec.rb` |
| `paritals` → `partials` | `spec/unit/renderer_spec.rb` |
| `load_curent_value` → `load_current_value` | `examples/stubs_for/resources/old.rb` |
| `touchs` → `touches` | `examples/remote_file/spec/touch_spec.rb` |
| `evalute` → `evaluate` | `examples/guards/spec/default_spec.rb` |
| `serivce` → `service` | 4 files under `examples/` |
| `optionss` → `options` | `examples/http_request/spec/options_spec.rb` |
| `maniuplated` → `manipulated`, `Signifant` → `Significant` | `CHANGELOG.md` |

Two scanner hits were deliberately **not** changed, since both are correct as written:

- `DracoAter` in `lib/chefspec/cacher.rb` and `CHANGELOG.md` — a GitHub username, flagged for the substring `Ater`.
- `# Hax.` in `lib/chefspec/extensions/chef/cookbook_loader.rb` — intentional slang, not a misspelling of `Hex`.

The two `CHANGELOG.md` entries are the only historical-record edits here; happy to drop that file from the PR if you would rather leave released notes as-is.

## Types of changes

- [x] Documentation / non-functional cleanup

## Checklist

- [x] Changes are limited to comments, test descriptions, and docs
- [x] All modified Ruby files pass `ruby -c`; the ERB template still parses
- [x] `typos` reports no remaining hits apart from the two intentional exclusions above