### PR TITLE
Document all public objects with YARD

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--readme README.md
+--output-dir doc
+lib/**/*.rb
+-
+CONTRIBUTING.md
+LICENSE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,19 @@ Documentation
 Documentation is a crucial part to ChefSpec, especially given its broad depth of features. All documentation is placed inline on the method matcher so it can be generated with [YARD](https://yardoc.org/). Please see existing matchers for an example.
 
 When contributing new features, please ensure adequate documentation and examples are present.
+
+**Every public class, module, constant, attribute, and method in `lib/` should carry a YARD comment.** You can check this before opening a pull request:
+
+```sh
+bundle exec rake yard:coverage  # report anything public that is undocumented
+bundle exec rake yard           # build the HTML docs into doc/
+```
+
+`rake yard:coverage` exits non-zero and names the offending `file:line` when something is missing, so it can also be wired into a local pre-commit hook if you find that useful.
+
+A few conventions worth knowing:
+
+- Docstrings use **RDoc markup**, not Markdown. Wrap inline code in plus signs (`+template+`), not backticks.
+- Use `{ChefSpec::Matchers::LinkToMatcher}` to link to something defined in this gem. For classes that live in another gem, such as `+Chef::Resource+` or `+Mash+`, use plus signs — YARD cannot resolve a link to a class it has not parsed, and doing so adds a build warning.
+- A docstring made up of nothing but tags counts as undocumented. `# @api private` on its own will not satisfy the check; add a sentence explaining what the object is for alongside the tag.
+- Private and protected methods are not required to have comments, though they are welcome.

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,13 @@ require "chef/version"
 
 YARD::Rake::YardocTask.new
 
+namespace :yard do
+  desc "Verify that every public object in lib/ has YARD documentation."
+  task :coverage do
+    ruby File.join(__dir__, "tasks", "yard_coverage.rb")
+  end
+end
+
 RSpec::Core::RakeTask.new(:unit) do |t|
   t.rspec_opts = [].tap do |a|
     a.push("--color")

--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -1,5 +1,13 @@
 require "rspec"
 
+#
+# ChefSpec is a unit testing framework for Chef cookbooks.
+#
+# It converges a recipe in memory, without provisioning a machine, and exposes
+# the resulting resource collection through a set of RSpec matchers. The two
+# entry points are {ChefSpec::SoloRunner} and {ChefSpec::ServerRunner}; nearly
+# everything else in this namespace supports those.
+#
 module ChefSpec
   #
   # Defines a new runner method on the Chef runner.

--- a/lib/chefspec/api.rb
+++ b/lib/chefspec/api.rb
@@ -1,4 +1,10 @@
 module ChefSpec
+  #
+  # Namespace for the RSpec-facing ChefSpec DSL.
+  #
+  # Each module here contributes matchers or helpers to example groups. They are
+  # autoloaded, and {included} mixes the whole set in at once.
+  #
   module API
     autoload :Core, "chefspec/api/core"
     autoload :Described, "chefspec/api/described"
@@ -15,6 +21,14 @@ module ChefSpec
     autoload :Subscriptions, "chefspec/api/subscriptions"
     autoload :User, "chefspec/api/user"
 
+    #
+    # Mix every ChefSpec API module into the given example group.
+    #
+    # @param [Class] klass
+    #   the RSpec example group to extend
+    #
+    # @return [void]
+    #
     def self.included(klass)
       # non-resources
       klass.include(ChefSpec::API::Core)

--- a/lib/chefspec/api/core.rb
+++ b/lib/chefspec/api/core.rb
@@ -205,6 +205,14 @@ module ChefSpec
           @chefspec_step_into |= resources.flatten.map(&:to_s)
         end
 
+        # Extend the example group with {ClassMethods}, and default its subject
+        # to the Chef run when the describe block targets a recipe, resource, or
+        # provider.
+        #
+        # @param [Class] klass
+        #   the example group including this module
+        # @return [void]
+        #
         # @api private
         def included(klass)
           super

--- a/lib/chefspec/api/described.rb
+++ b/lib/chefspec/api/described.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Helpers for deriving the cookbook and recipe under test from the enclosing +describe+ block.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Described
       #
       # The name of the currently running cookbook spec. Given the top-level

--- a/lib/chefspec/api/do_nothing.rb
+++ b/lib/chefspec/api/do_nothing.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +do_nothing+ matcher for asserting a resource took no action.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module DoNothing
       #
       # Assert that a resource in the Chef run does not perform any actions. Given

--- a/lib/chefspec/api/include_any_recipe.rb
+++ b/lib/chefspec/api/include_any_recipe.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +include_any_recipe+ matcher.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module IncludeAnyRecipe
       #
       # Assert that a Chef run includes any recipe.

--- a/lib/chefspec/api/include_recipe.rb
+++ b/lib/chefspec/api/include_recipe.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +include_recipe+ matcher.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module IncludeRecipe
       #
       # Assert that a Chef run includes a certain recipe. Given a Chef Recipe

--- a/lib/chefspec/api/link.rb
+++ b/lib/chefspec/api/link.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +link_to+ matcher for asserting on symlink targets.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Link
       #
       # Assert that a symlink links to a specific path. This is really

--- a/lib/chefspec/api/notifications.rb
+++ b/lib/chefspec/api/notifications.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +notify+ matcher for asserting on resource notifications.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Notifications
       #
       # Assert that a resource notifies another. Given a Chef Recipe that

--- a/lib/chefspec/api/reboot.rb
+++ b/lib/chefspec/api/reboot.rb
@@ -1,10 +1,37 @@
 module ChefSpec
   module API
+    #
+    # Matchers for the +reboot+ resource, whose actions do not follow the usual naming pattern.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Reboot
+      #
+      # Assert that a +reboot+ resource performed the +:reboot_now+ action.
+      #
+      # @example
+      #   expect(chef_run).to now_reboot("app server")
+      #
+      # @param [String] resource_name
+      #   the name of the reboot resource
+      #
+      # @return [ChefSpec::Matchers::ResourceMatcher]
+      #
       def now_reboot(resource_name)
         ChefSpec::Matchers::ResourceMatcher.new(:reboot, :reboot_now, resource_name)
       end
 
+      #
+      # Assert that a +reboot+ resource performed the +:request_reboot+ action.
+      #
+      # @example
+      #   expect(chef_run).to request_reboot("app server")
+      #
+      # @param [String] resource_name
+      #   the name of the reboot resource
+      #
+      # @return [ChefSpec::Matchers::ResourceMatcher]
+      #
       def request_reboot(resource_name)
         ChefSpec::Matchers::ResourceMatcher.new(:reboot, :request_reboot, resource_name)
       end

--- a/lib/chefspec/api/render_file.rb
+++ b/lib/chefspec/api/render_file.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +render_file+ matcher for asserting on rendered file content.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module RenderFile
       #
       # Assert that a file is rendered by the Chef run. This matcher works for

--- a/lib/chefspec/api/state_attrs.rb
+++ b/lib/chefspec/api/state_attrs.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +have_state_attrs+ matcher.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module StateAttrs
       #
       # Assert that a Chef resource has certain state attributes (since Chef

--- a/lib/chefspec/api/stubs.rb
+++ b/lib/chefspec/api/stubs.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides +stub_command+, +stub_search+, +stub_data_bag+, and +stub_data_bag_item+ for stubbing calls that would otherwise reach the outside world.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Stubs
       #
       # Stub a shell command to return a particular value without

--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -3,6 +3,15 @@ require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module ChefSpec
   module API
+    #
+    # Injects RSpec stubs into resource, provider, and current_value objects that
+    # a converge builds internally.
+    #
+    # Those objects are created deep inside Chef, so an example cannot get a
+    # reference to them in time to stub them. Instead, blocks registered through
+    # {#stubs_for_resource} and friends are replayed against each object as Chef
+    # instantiates it.
+    #
     module StubsFor
       # Pull in the needed machinery to use `before` here.
       extend RSpec::SharedContext
@@ -83,6 +92,32 @@ module ChefSpec
         _chefspec_stubs_for_registry[:provider][target] << block
       end
 
+      #
+      # Build an RSpec message expectation for a +shell_out+ call, returning a
+      # canned +Mixlib::ShellOut+ result instead of running the command.
+      #
+      # @example
+      #   stubs_for_resource("my_resource[foo]") do |res|
+      #     expect(res).to receive_shell_out.with("my_command").and_return(stdout: "asdf")
+      #   end
+      #
+      # @param [Array<String>] cmd
+      #   the command the resource is expected to run
+      #
+      # @param [String] stdout
+      #   the standard output to return
+      #
+      # @param [String] stderr
+      #   the standard error to return
+      #
+      # @param [Integer] exitstatus
+      #   the exit status to return
+      #
+      # @param [Hash] opts
+      #   additional options the call must have been made with
+      #
+      # @return [RSpec::Mocks::Matchers::Receive]
+      #
       def receive_shell_out(*cmd, stdout: "", stderr: "", exitstatus: 0, **opts)
         # Ruby does not allow constructing an actual exitstatus object from Ruby code. Really.
         fake_exitstatus = double(exitstatus: exitstatus)
@@ -100,6 +135,10 @@ module ChefSpec
         receive(shell_out_method).with(*with_args).and_return(fake_cmd)
       end
 
+      #
+      # Group-level counterparts to the instance methods above, so that stubs can
+      # be declared once for a whole +describe+ block.
+      #
       module ClassMethods
         # (see StubsFor#stubs_for_resource)
         def stubs_for_resource(*args, **kwargs, &block)
@@ -117,6 +156,13 @@ module ChefSpec
           before { stubs_for_provider(*args, &block) }
         end
 
+        # Extend the example group with {ClassMethods} so that stubs can be
+        # declared at the group level.
+        #
+        # @param [Class] klass
+        #   the example group including this module
+        # @return [void]
+        #
         # @api private
         def included(klass)
           super

--- a/lib/chefspec/api/subscriptions.rb
+++ b/lib/chefspec/api/subscriptions.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Provides the +subscribe_to+ matcher for asserting on resource subscriptions.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module Subscriptions
       #
       # Assert that a resource subscribes to another. Given a Chef Recipe that

--- a/lib/chefspec/api/user.rb
+++ b/lib/chefspec/api/user.rb
@@ -1,5 +1,10 @@
 module ChefSpec
   module API
+    #
+    # Matchers for the +user+ resource, whose actions do not follow the usual naming pattern.
+    #
+    # Mixed into every example group by {ChefSpec::API.included}.
+    #
     module User
       ChefSpec.define_matcher :user
 

--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -5,6 +5,13 @@ rescue LoadError
 end
 
 module ChefSpec
+  #
+  # Resolves cookbook dependencies with Berkshelf before the Chef run.
+  #
+  # Enabled by requiring +chefspec/berkshelf+. Vendors the Berksfile into a
+  # temporary directory and points +cookbook_path+ at it for the duration of
+  # the suite.
+  #
   class Berkshelf
     class << self
       extend Forwardable

--- a/lib/chefspec/cacher.rb
+++ b/lib/chefspec/cacher.rb
@@ -31,8 +31,30 @@ module ChefSpec
   #
   module Cacher
     @@cache = {}
+    #
+    # Drops a thread's cached results when that thread is garbage collected, so
+    # the cache does not grow without bound in threaded runs.
+    #
     FINALIZER = lambda { |id| @@cache.delete(id) }
 
+    #
+    # Define a memoized helper, like RSpec's +let+, whose value is cached across
+    # every example in the group rather than rebuilt per example.
+    #
+    # The cache key is derived from the example group's source location, so two
+    # groups declaring the same name do not collide.
+    #
+    # @example
+    #   cached(:chef_run) { ChefSpec::SoloRunner.converge("example::default") }
+    #
+    # @param [Symbol, String] name
+    #   the name of the helper method to define
+    #
+    # @yieldreturn [Object]
+    #   the value to cache
+    #
+    # @return [void]
+    #
     def cached(name, &block)
       location = ancestors.first.metadata[:location]
       unless location.nil?
@@ -51,6 +73,18 @@ module ChefSpec
       end
     end
 
+    #
+    # Like {#cached}, but eagerly evaluates the block in a +before+ hook instead
+    # of waiting for the first example to reference it.
+    #
+    # @param [Symbol, String] name
+    #   the name of the helper method to define
+    #
+    # @yieldreturn [Object]
+    #   the value to cache
+    #
+    # @return [void]
+    #
     def cached!(name, &block)
       cached(name, &block)
 

--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -1,11 +1,37 @@
 require_relative "coverage/filters"
 
 module ChefSpec
+  #
+  # Tracks which resources in the cookbook were exercised by the test suite.
+  #
+  # This is a singleton that resources register themselves with as they run.
+  # {.method_added} forwards every public instance method to the singleton, so
+  # the whole API is usable as +ChefSpec::Coverage.report!+ and friends.
+  #
+  # @example Enabling coverage reporting in +spec_helper.rb+
+  #   ChefSpec::Coverage.start!
+  #
   class Coverage
+    #
+    # Process exit status used when the run failed.
+    #
     EXIT_FAILURE = 1
+    #
+    # Process exit status used when the run succeeded.
+    #
     EXIT_SUCCESS = 0
 
     class << self
+      #
+      # Forward newly defined public instance methods to the singleton, so callers
+      # can use +ChefSpec::Coverage.foo+ rather than
+      # +ChefSpec::Coverage.instance.foo+.
+      #
+      # @param [Symbol] name
+      #   the name of the method that was just defined
+      #
+      # @return [void]
+      #
       def method_added(name)
         # Only delegate public methods
         if method_defined?(name)
@@ -199,6 +225,12 @@ module ChefSpec
       !find(resource).nil?
     end
 
+    #
+    # Wraps a +Chef::Resource+ with the bookkeeping the coverage report needs.
+    #
+    # Records where the resource was declared and whether any matcher touched it
+    # during the run.
+    #
     class ResourceWrapper
       attr_reader :resource
 
@@ -206,10 +238,20 @@ module ChefSpec
         @resource = resource
       end
 
+      #
+      # The string form of the wrapped resource, such as +template[/etc/foo]+.
+      #
+      # @return [String]
+      #
       def to_s
         @resource.to_s
       end
 
+      #
+      # The wrapped resource as a JSON object, used by the JSON coverage report.
+      #
+      # @return [String]
+      #
       def to_json
         {
           "source_file" => source_file,
@@ -219,6 +261,12 @@ module ChefSpec
         }.to_json
       end
 
+      #
+      # The cookbook-relative path of the file that declared the resource.
+      #
+      # @return [String]
+      #   the shortened path, or +"Unknown"+ if the resource has no source line
+      #
       def source_file
         @source_file ||= if @resource.source_line
                            shortname(@resource.source_line.split(":").first)
@@ -227,6 +275,12 @@ module ChefSpec
                          end
       end
 
+      #
+      # The line number the resource was declared on.
+      #
+      # @return [Integer, String]
+      #   the line number, or +"Unknown"+ if the resource has no source line
+      #
       def source_line
         @source_line ||= if @resource.source_line
                            @resource.source_line.split(":", 2).last.to_i
@@ -235,6 +289,11 @@ module ChefSpec
                          end
       end
 
+      #
+      # Mark the resource as exercised by the test suite.
+      #
+      # @return [true]
+      #
       def touch!
         @touched = true
       end

--- a/lib/chefspec/coverage/filters.rb
+++ b/lib/chefspec/coverage/filters.rb
@@ -1,5 +1,11 @@
 module ChefSpec
   class Coverage
+    #
+    # Base class for filters that exclude resources from the coverage report.
+    #
+    # Subclasses must override {#matches?}. Filters are registered with
+    # +ChefSpec::Coverage.add_filter+.
+    #
     class Filter
       def initialize(filter)
         @filter = filter

--- a/lib/chefspec/deprecations.rb
+++ b/lib/chefspec/deprecations.rb
@@ -1,3 +1,9 @@
+#
+# Reopened to add {#deprecated}, so that deprecation notices can be emitted
+# from anywhere in ChefSpec without a receiver.
+#
+# @api private
+#
 module Kernel
   # Kernel extension to print deprecation notices.
   #
@@ -31,6 +37,10 @@ module ChefSpec
     end
   end
 
+  #
+  # @deprecated There is no longer a global Chef Server instance. Use
+  #   {ChefSpec::ServerRunner} instead.
+  #
   class Server
     def self.method_missing(m, *args, &block)
       deprecated "`ChefSpec::Server.#{m}' is deprecated. There is no longer" \
@@ -42,5 +52,8 @@ module ChefSpec
 end
 
 module ChefSpec::Error
+  #
+  # Raised when a deprecated method has no backwards compatible replacement.
+  #
   class NoConversionError < ChefSpecError; end
 end

--- a/lib/chefspec/errors.rb
+++ b/lib/chefspec/errors.rb
@@ -1,6 +1,35 @@
 module ChefSpec
+  #
+  # Namespace for all ChefSpec exceptions.
+  #
+  # Every error in this namespace renders its message from an ERB template in
+  # +templates/errors+. The template is chosen by underscoring the class name,
+  # so {CookbookPathNotFound} renders +cookbook_path_not_found.erb+. This keeps
+  # long, user-facing explanations out of the Ruby source.
+  #
   module Error
+    #
+    # The base class for all ChefSpec errors.
+    #
+    # Subclasses do not usually define a message. Instead they rely on this
+    # constructor to locate the matching ERB template and evaluate it with the
+    # options passed in.
+    #
+    # @example Defining an error backed by +templates/errors/my_error.erb+
+    #   class MyError < ChefSpecError; end
+    #   raise MyError.new(name: "thing")
+    #
     class ChefSpecError < StandardError
+      #
+      # Create a new error, rendering its message from an ERB template.
+      #
+      # @param [Hash] options
+      #   the local variables to expose to the ERB template
+      #
+      # @option options [String, Symbol] :_template
+      #   the template basename to render, overriding the underscored class
+      #   name that would otherwise be used
+      #
       def initialize(options = {})
         class_name = self.class.to_s.split("::").last
         filename   = options.delete(:_template) || Util.underscore(class_name)
@@ -11,7 +40,25 @@ module ChefSpec
       end
     end
 
+    #
+    # Raised when a cookbook calls out to the real world instead of a stub.
+    #
+    # All subclasses share the +not_stubbed.erb+ template, which prints the
+    # unstubbed call alongside a copy-pasteable stub that would satisfy it. The
+    # subclass name drives both the human-readable type and the {Stubs} class
+    # used to build that example, so +SearchNotStubbed+ resolves to
+    # +ChefSpec::Stubs::SearchStub+.
+    #
     class NotStubbed < ChefSpecError
+      #
+      # Create a new error describing the call that was not stubbed.
+      #
+      # @param [Hash] options
+      #   the options passed through to the ERB template
+      #
+      # @option options [Array] :args
+      #   the arguments the cookbook used, replayed to build the suggested stub
+      #
       def initialize(options = {})
         name  = self.class.name.to_s.split("::").last
         type  = Util.underscore(name).gsub("_not_stubbed", "")
@@ -29,21 +76,43 @@ module ChefSpec
       end
     end
 
+    # Raised when a cookbook shells out to a command that was not stubbed.
     class CommandNotStubbed < NotStubbed; end
+
+    # Raised when a cookbook performs a search that was not stubbed.
     class SearchNotStubbed < NotStubbed; end
+
+    # Raised when a cookbook loads a data bag that was not stubbed.
     class DataBagNotStubbed < NotStubbed; end
+
+    # Raised when a cookbook loads a data bag item that was not stubbed.
     class DataBagItemNotStubbed < NotStubbed; end
+
+    # Raised when a resource calls +shell_out+ without a matching stub.
     class ShellOutNotStubbed < ChefSpecError; end
+
+    # Raised when +Chef::Mixin::ShellOut+ is used without a matching stub.
     class MixinShellOutNotStubbed < ChefSpecError; end
 
+    # Raised when the cookbook path could not be found or inferred.
     class CookbookPathNotFound < ChefSpecError; end
+
+    # Raised when an optional integration gem, such as Berkshelf, is missing.
     class GemLoadError < ChefSpecError; end
 
+    #
+    # Raised when a resource could not be found, which usually means the
+    # example did not specify the platform the resource is available on.
+    #
     class MayNeedToSpecifyPlatform < ChefSpecError; end
 
+    # Raised when +berkshelf_options+ is not a hash with symbol keys.
     class InvalidBerkshelfOptions < ChefSpecError; end
 
+    # Raised when the configured coverage report template cannot be found.
     class TemplateNotFound < ChefSpecError; end
+
+    # Raised when an ERB template could not be parsed while rendering.
     class ErbTemplateParseError < ChefSpecError; end
   end
 end

--- a/lib/chefspec/expect_exception.rb
+++ b/lib/chefspec/expect_exception.rb
@@ -1,14 +1,45 @@
+#
+# Reopened so ChefSpec can see the most recently run +raise_error+ matcher.
+#
+# Chef swallows exceptions inside the converge and reports them through the
+# formatter instead of re-raising, so {ChefSpec::ExpectException} needs the
+# matcher itself to decide whether the failure was the expected one.
+#
+# @api private
+#
 class RSpec::Matchers::BuiltIn::RaiseError
   class << self
+    #
+    # The most recently evaluated +raise_error+ matcher, recorded so ChefSpec
+    # can consult it after Chef swallows the exception.
+    #
+    # @return [RSpec::Matchers::BuiltIn::RaiseError, nil]
+    #
     attr_accessor :last_run
   end
 
+  #
+  # The message this matcher was built to expect.
+  #
+  # @return [String, Regexp, nil]
+  #
   attr_reader :expected_message
 
+  #
+  # The error class or instance this matcher was built to expect.
+  #
+  # @return [Exception, Class, nil]
+  #
   def last_error_for_chefspec
     @expected_error
   end
 
+  #
+  # The original RSpec implementation of +matches?+, preserved so the
+  # override below can record the matcher and then delegate to it.
+  #
+  # @return [true, false]
+  #
   alias_method :old_matches?, :matches?
   def matches?(*args)
     self.class.last_run = self
@@ -17,6 +48,13 @@ class RSpec::Matchers::BuiltIn::RaiseError
 end
 
 module ChefSpec
+  #
+  # Decides whether an exception reported by the Chef formatter is the one the
+  # example was expecting.
+  #
+  # Compares the formatter's exception and message against the most recently
+  # run +raise_error+ matcher.
+  #
   class ExpectException
     def initialize(formatter_exception, formatter_message = nil)
       @formatter_exception = formatter_exception

--- a/lib/chefspec/extensions.rb
+++ b/lib/chefspec/extensions.rb
@@ -1,6 +1,16 @@
 require "rspec"
 
+#
+# Namespace for the monkey patches ChefSpec applies to Chef and Ohai.
+#
+# These are what stop a converge from touching the real system: shelling out,
+# uploading cookbooks, and running providers are all intercepted here. The
+# require order below is load-bearing.
+#
 module ChefSpec::Extensions
+  #
+  # Patches applied to Chef itself.
+  #
   module Chef
   end
 end

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -27,6 +27,12 @@ module ChefSpec::Extensions::Chef::Resource
     end
   end
 
+  #
+  # Duplicate the resource, re-registering +stubs_for+ hooks when the copy is
+  # being made on behalf of +load_current_value+.
+  #
+  # @return [Chef::Resource]
+  #
   def dup
     return super unless $CHEFSPEC_MODE
 
@@ -73,6 +79,15 @@ module ChefSpec::Extensions::Chef::Resource
     @performed_actions[action.to_sym].merge!(options)
   end
 
+  #
+  # The options recorded when the resource performed the given action.
+  #
+  # @param [Symbol, String] action
+  #   the action to look up
+  #
+  # @return [Hash, nil]
+  #   the recorded options, or +nil+ if the action was never performed
+  #
   def performed_action(action)
     @performed_actions ||= {}
     @performed_actions[action.to_sym]
@@ -86,6 +101,11 @@ module ChefSpec::Extensions::Chef::Resource
     end
   end
 
+  #
+  # Every action the resource performed during the Chef run.
+  #
+  # @return [Array<Symbol>]
+  #
   def performed_actions
     @performed_actions ||= {}
     @performed_actions.keys
@@ -101,12 +121,28 @@ module ChefSpec::Extensions::Chef::Resource
     end
   end
 
+  #
+  # Prepended onto every resource's singleton class so that declaring a
+  # resource name, provides line, or action automatically defines the
+  # matching ChefSpec matcher.
+  #
+  # This is what makes +create_my_resource("foo")+ work for a custom resource
+  # without any extra registration.
+  #
   module ClassMethods
     # XXX: kind of a crappy way to find all the names of a resource
     def provides_names
       @provides_names ||= []
     end
 
+    #
+    # Record the resource name and define matchers for its allowed actions.
+    #
+    # @param [Symbol] name
+    #   the resource name being declared
+    #
+    # @return [Symbol]
+    #
     def resource_name(name = ::Chef::NOT_PASSED)
       unless name == ::Chef::NOT_PASSED
         provides_names << name unless provides_names.include?(name)
@@ -115,22 +151,60 @@ module ChefSpec::Extensions::Chef::Resource
       super
     end
 
+    #
+    # Record the provided name and define matchers for its allowed actions.
+    #
+    # @param [Symbol] name
+    #   the resource name being provided
+    #
+    # @param [Hash] options
+    #   the platform filters passed through to Chef
+    #
+    # @return [void]
+    #
     def provides(name, **options, &block)
       provides_names << name unless provides_names.include?(name)
       inject_actions(*allowed_actions)
       super
     end
 
+    #
+    # Define an action and its corresponding ChefSpec matcher.
+    #
+    # @param [Symbol] sym
+    #   the action being defined
+    #
+    # @param [String, nil] description
+    #   the action description passed through to Chef
+    #
+    # @return [void]
+    #
     def action(sym, description: nil, &block)
       inject_actions(sym)
       super(sym, &block)
     end
 
+    #
+    # Declare allowed actions and define matchers for each of them.
+    #
+    # @param [Array<Symbol>] actions
+    #   the actions to allow
+    #
+    # @return [Array<Symbol>]
+    #
     def allowed_actions(*actions)
       inject_actions(*actions) unless actions.empty?
       super
     end
 
+    #
+    # Replace the allowed actions and define matchers for each of them.
+    #
+    # @param [Array<Symbol>, Symbol] value
+    #   the actions to allow
+    #
+    # @return [Array<Symbol>]
+    #
     def allowed_actions=(value)
       inject_actions(*Array(value))
       super

--- a/lib/chefspec/extensions/chef/securable.rb
+++ b/lib/chefspec/extensions/chef/securable.rb
@@ -1,7 +1,25 @@
 require "chef/mixin/securable"
 
+#
+# Reopened to make the Windows security attributes available on every
+# platform.
+#
+# @api private
+#
 class Chef
+  #
+  # Namespace for Chef's resource mixins.
+  #
+  # @api private
+  #
   module Mixin
+    #
+    # Chef only includes the Windows security attributes when running on
+    # Windows. ChefSpec includes them everywhere so that Windows resources can
+    # be tested from any platform.
+    #
+    # @api private
+    #
     module Securable
       # In Chef, this module is only included if the RUBY_PLATFORM is
       # Windows-like. In ChefSpec, we want to include this, regardless of the
@@ -9,6 +27,14 @@ class Chef
       # critical in testing Windows resources.
       include WindowsSecurableAttributes
 
+      #
+      # Extend the including resource with the Windows rights attributes.
+      #
+      # @param [Class] including_class
+      #   the resource class including this mixin
+      #
+      # @return [void]
+      #
       def self.included(including_class)
         including_class.extend(WindowsMacros)
         including_class.rights_attribute(:rights)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -4,6 +4,10 @@ require "chef/version"
 require_relative "../../api/stubs_for"
 require_relative "../../errors"
 
+#
+# Prepended onto +Chef::Resource+ so that a resource shelling out during a
+# ChefSpec run raises instead of executing the command.
+#
 module ::ChefSpec::Extensions::Chef::ResourceShellOut
   #
   # Defang shell_out and friends so it can never run.
@@ -14,6 +18,16 @@ module ::ChefSpec::Extensions::Chef::ResourceShellOut
     raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
   end
 
+  #
+  # Raise rather than executing the command, matching the bang variant's
+  # contract of failing on a non-zero exit status.
+  #
+  # @param [Array] args
+  #   the command and options the caller passed
+  #
+  # @raise [ChefSpec::Error::ShellOutNotStubbed, ChefSpec::Error::MixinShellOutNotStubbed]
+  #   when running under ChefSpec without a matching stub
+  #
   def shell_out_compacted!(*args)
     return super unless $CHEFSPEC_MODE
 
@@ -21,6 +35,10 @@ module ::ChefSpec::Extensions::Chef::ResourceShellOut
   end
 end
 
+#
+# Prepended onto +Chef::Mixin::ShellOut+ so that library code shelling out
+# during a ChefSpec run raises instead of executing the command.
+#
 module ::ChefSpec::Extensions::Chef::MixinShellOut
   #
   # Defang shell_out and friends so it can never run.
@@ -31,6 +49,16 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
     raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
   end
 
+  #
+  # Raise rather than executing the command, matching the bang variant's
+  # contract of failing on a non-zero exit status.
+  #
+  # @param [Array] args
+  #   the command and options the caller passed
+  #
+  # @raise [ChefSpec::Error::ShellOutNotStubbed, ChefSpec::Error::MixinShellOutNotStubbed]
+  #   when running under ChefSpec without a matching stub
+  #
   def shell_out_compacted!(*args)
     return super unless $CHEFSPEC_MODE
 

--- a/lib/chefspec/file_cache_path_proxy.rb
+++ b/lib/chefspec/file_cache_path_proxy.rb
@@ -2,6 +2,13 @@ require "fileutils" unless defined?(FileUtils)
 require "singleton" unless defined?(Singleton)
 
 module ChefSpec
+  #
+  # Supplies a single temporary +file_cache_path+ for the whole suite.
+  #
+  # {ChefSpec::ServerRunner} needs the path to stay constant across runs, or
+  # Chef reloads the same cookbook repeatedly. The directory is removed at
+  # process exit.
+  #
   class FileCachePathProxy
     include Singleton
 

--- a/lib/chefspec/formatter.rb
+++ b/lib/chefspec/formatter.rb
@@ -2,12 +2,27 @@ require "chef/formatters/base"
 require "chef/formatters/error_mapper"
 
 module ChefSpec
+  #
+  # A Chef output formatter that stays silent.
+  #
+  # ChefSpec reports through RSpec, so nearly every formatter callback here is
+  # a deliberate no-op. The exception is error reporting, which is forwarded so
+  # that a failed converge still produces a useful message.
+  #
   class ChefFormatter < Chef::Formatters::Base
     cli_name :chefspec
 
     # Called at the very start of a Chef Run
     def run_start(version); end
 
+    #
+    # Called when the Chef run starts.
+    #
+    # @param [Chef::RunStatus] run_status
+    #   the status object for this run
+    #
+    # @return [void]
+    #
     def run_started(run_status); end
 
     # Called at the end a successful Chef run.
@@ -25,6 +40,11 @@ module ChefSpec
     # About to attempt to register as +node_name+
     def registration_start(node_name, config); end
 
+    #
+    # Called once the node has registered with the Chef Infra Server.
+    #
+    # @return [void]
+    #
     def registration_completed; end
 
     # Failed to register this client with the server.

--- a/lib/chefspec/librarian.rb
+++ b/lib/chefspec/librarian.rb
@@ -9,6 +9,13 @@ rescue LoadError
 end
 
 module ChefSpec
+  #
+  # Resolves cookbook dependencies with Librarian-Chef before the Chef run.
+  #
+  # Enabled by requiring +chefspec/librarian+. Installs the Cheffile into a
+  # temporary directory and points +cookbook_path+ at it for the duration of
+  # the suite.
+  #
   class Librarian
     class << self
       extend Forwardable

--- a/lib/chefspec/matchers.rb
+++ b/lib/chefspec/matchers.rb
@@ -1,4 +1,10 @@
 module ChefSpec
+  #
+  # Namespace for the RSpec matcher objects backing the ChefSpec DSL.
+  #
+  # Matchers here are not usually built directly; the {ChefSpec::API} modules
+  # and the generated +action_resource+ helpers construct them.
+  #
   module Matchers
     require_relative "matchers/do_nothing_matcher"
     require_relative "matchers/include_any_recipe_matcher"

--- a/lib/chefspec/matchers/do_nothing_matcher.rb
+++ b/lib/chefspec/matchers/do_nothing_matcher.rb
@@ -1,5 +1,24 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that a resource performed no actions during the Chef run.
+  #
+  # Built by {ChefSpec::API::DoNothing#do_nothing}. A resource matches when it
+  # performed no actions at all, or only the +:nothing+ action.
+  #
+  # @example
+  #   expect(chef_run.service("apache2")).to do_nothing
+  #
   class DoNothingMatcher
+    #
+    # Determine whether the resource performed anything other than +:nothing+.
+    #
+    # Marks the resource as covered in the coverage report as a side effect.
+    #
+    # @param [Chef::Resource] resource
+    #   the resource to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(resource)
       @resource = resource
 
@@ -13,10 +32,21 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       "do nothing"
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       if @resource
         message =  %{expected #{@resource} to do nothing, but the following }
@@ -37,6 +67,11 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       if @resource
         message =  %{expected #{@resource} to do something, but no actions }

--- a/lib/chefspec/matchers/include_any_recipe_matcher.rb
+++ b/lib/chefspec/matchers/include_any_recipe_matcher.rb
@@ -1,18 +1,53 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that the Chef run included at least one recipe that was not
+  # already named in the node's run list.
+  #
+  # Built by {ChefSpec::API::IncludeAnyRecipe#include_any_recipe}. This is the
+  # matcher to reach for when you care that +include_recipe+ was called at all,
+  # but not which recipe it pulled in.
+  #
+  # @example
+  #   expect(chef_run).to include_any_recipe
+  #
   class IncludeAnyRecipeMatcher
+    #
+    # Determine whether any recipe was loaded beyond the run list itself.
+    #
+    # @param [ChefSpec::SoloRunner, ChefSpec::ServerRunner] runner
+    #   the converged runner to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(runner)
       @runner = runner
       !(loaded_recipes - run_list_recipes).empty?
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       "include any recipe"
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       "expected to include any recipe"
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       "expected not to include any recipes"
     end

--- a/lib/chefspec/matchers/include_recipe_matcher.rb
+++ b/lib/chefspec/matchers/include_recipe_matcher.rb
@@ -1,22 +1,62 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that the Chef run loaded a specific recipe.
+  #
+  # Built by {ChefSpec::API::IncludeRecipe#include_recipe}. Recipe names are
+  # normalized before comparison, so +"nginx"+ and +"nginx::default"+ are
+  # treated as the same recipe.
+  #
+  # @example
+  #   expect(chef_run).to include_recipe("nginx::source")
+  #
   class IncludeRecipeMatcher
+    #
+    # Create a new matcher for the given recipe.
+    #
+    # @param [String] recipe_name
+    #   the recipe to look for, with or without an explicit +::default+
+    #
     def initialize(recipe_name)
       @recipe_name = with_default(recipe_name)
     end
 
+    #
+    # Determine whether the recipe is among those loaded by the Chef run.
+    #
+    # @param [ChefSpec::SoloRunner, ChefSpec::ServerRunner] runner
+    #   the converged runner to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(runner)
       @runner = runner
       loaded_recipes.include?(@recipe_name)
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       %Q{include recipe "#{@recipe_name}"}
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       %Q{expected #{loaded_recipes.inspect} to include "#{@recipe_name}"}
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       %Q{expected "#{@recipe_name}" to not be included}
     end

--- a/lib/chefspec/matchers/link_to_matcher.rb
+++ b/lib/chefspec/matchers/link_to_matcher.rb
@@ -1,9 +1,34 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that a +link+ resource points at a given target.
+  #
+  # Built by {ChefSpec::API::Link#link_to}. The target is compared with +===+,
+  # so a regular expression may be given instead of a literal path.
+  #
+  # @example
+  #   expect(chef_run.link("/tmp/thing")).to link_to("/tmp/other_thing")
+  #
   class LinkToMatcher
+    #
+    # Create a new matcher for the given link target.
+    #
+    # @param [String, Regexp] path
+    #   the path the link is expected to point at
+    #
     def initialize(path)
       @path = path
     end
 
+    #
+    # Determine whether the resource is a created link pointing at the target.
+    #
+    # Marks the resource as covered in the coverage report as a side effect.
+    #
+    # @param [Chef::Resource::Link] link
+    #   the link resource to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(link)
       @link = link
 
@@ -18,10 +43,21 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       %Q{link to "#{@path}"}
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       if @link.nil?
         %Q{expected "link[#{@path}]" with action :create to be in Chef run}
@@ -30,6 +66,11 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       %Q{expected "#{@link}" to not link to "#{@path}"}
     end

--- a/lib/chefspec/matchers/notifications_matcher.rb
+++ b/lib/chefspec/matchers/notifications_matcher.rb
@@ -1,13 +1,42 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that a resource notified another resource.
+  #
+  # Built by {ChefSpec::API::Notifications#notify}. By default any notification
+  # to the target resource matches; chain {#to}, {#immediately}, {#delayed}, or
+  # {#before} to narrow the assertion.
+  #
+  # @example
+  #   expect(chef_run.template("/etc/foo")).to notify("service[apache2]")
+  #     .to(:restart).delayed
+  #
   class NotificationsMatcher
     include ChefSpec::Normalize
 
+    #
+    # Create a new matcher for the given resource signature.
+    #
+    # @param [String] signature
+    #   the notified resource in +type[name]+ form, such as
+    #   +"service[apache2]"+
+    #
     def initialize(signature)
       match = signature.match(/^([^\[]*)\[(.*)\]$/)
       @expected_resource_type = match[1]
       @expected_resource_name = match[2]
     end
 
+    #
+    # Determine whether the resource sent a matching notification.
+    #
+    # Only the notification timing selected by {#immediately}, {#delayed}, or
+    # {#before} is searched; with none of them set, all timings are searched.
+    #
+    # @param [Chef::Resource] resource
+    #   the notifying resource
+    #
+    # @return [true, false]
+    #
     def matches?(resource)
       @resource = resource
 
@@ -30,26 +59,55 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # Restrict the match to notifications sending a specific action.
+    #
+    # @param [Symbol, String] action
+    #   the action the notification must send, such as +:restart+
+    #
+    # @return [self]
+    #
     def to(action)
       @action = action.to_sym
       self
     end
 
+    #
+    # Restrict the match to immediate notifications.
+    #
+    # @return [self]
+    #
     def immediately
       @immediately = true
       self
     end
 
+    #
+    # Restrict the match to delayed notifications.
+    #
+    # @return [self]
+    #
     def delayed
       @delayed = true
       self
     end
 
+    #
+    # Restrict the match to +before+ notifications.
+    #
+    # @return [self]
+    #
     def before
       @before = true
       self
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       message = %Q{notify "#{@expected_resource_type}[#{@expected_resource_name}]"}
       message << " with action :#{@action}" if @action
@@ -59,6 +117,14 @@ module ChefSpec::Matchers
       message
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # Lists every notification the resource actually sent, which is usually
+    # enough to spot a wrong action or timing.
+    #
+    # @return [String]
+    #
     def failure_message
       if @resource
         message = %Q{expected "#{@resource}" to notify "#{@expected_resource_type}[#{@expected_resource_name}]"}
@@ -87,6 +153,11 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       if @resource
         message = %Q{expected "#{@resource}" to not notify "#{@expected_resource_type}[#{@expected_resource_name}]"}

--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -1,11 +1,38 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that the Chef run rendered a file at a given path.
+  #
+  # Built by {ChefSpec::API::RenderFile#render_file}. The path may be backed by
+  # a +cookbook_file+, +file+, or +template+ resource; chain {#with_content} to
+  # also assert on what was written.
+  #
+  # @example
+  #   expect(chef_run).to render_file("/etc/foo").with_content("bar")
+  #
   class RenderFileMatcher
     attr_reader :expected_content
+    #
+    # Create a new matcher for the given path.
+    #
+    # @param [String] path
+    #   the path the Chef run is expected to render
+    #
     def initialize(path)
       @path = path
       @expected_content = []
     end
 
+    #
+    # Determine whether the file was rendered with the expected content.
+    #
+    # Marks the backing resource as covered in the coverage report as a side
+    # effect.
+    #
+    # @param [ChefSpec::SoloRunner, ChefSpec::ServerRunner] runner
+    #   the converged runner to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(runner)
       @runner = runner
 
@@ -17,6 +44,31 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # Assert on the rendered content of the file.
+    #
+    # May be chained more than once, in which case every expectation must pass.
+    # Exactly one of +expected_content+ or a block must be given.
+    #
+    # @example Matching a substring
+    #   expect(chef_run).to render_file("/etc/foo").with_content("bar")
+    #
+    # @example Matching with a block
+    #   expect(chef_run).to render_file("/etc/foo").with_content { |content|
+    #     expect(content).to include("bar")
+    #   }
+    #
+    # @param [String, Regexp, RSpec::Matchers::BuiltIn::BaseMatcher] expected_content
+    #   the content to match against the rendered file
+    #
+    # @yieldparam [String] content
+    #   the rendered content, for making arbitrary assertions
+    #
+    # @raise [ArgumentError]
+    #   if both a value and a block are given, or neither is
+    #
+    # @return [self]
+    #
     def with_content(expected_content = nil, &block)
       if expected_content && block
         raise ArgumentError, "Cannot specify expected content and a block!"
@@ -31,6 +83,12 @@ module ChefSpec::Matchers
       self
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       message = %Q{render file "#{@path}"}
       @expected_content.each do |expected|
@@ -43,6 +101,11 @@ module ChefSpec::Matchers
       message
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       message = %Q{expected Chef run to render "#{@path}"}
       unless @expected_content.empty?
@@ -58,6 +121,11 @@ module ChefSpec::Matchers
       message
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       message = %Q{expected file "#{@path}"}
       unless @expected_content.empty?

--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -1,18 +1,64 @@
 require "rspec/expectations/fail_with"
 
 module ChefSpec::Matchers
+  #
+  # Asserts that the Chef run declared a resource that performed an action.
+  #
+  # This backs the generated +action_resource+ matchers, so
+  # +create_template("/etc/foo")+ builds a +ResourceMatcher+ for the +:create+
+  # action on +template[/etc/foo]+. Chain {#with} to assert on properties, and
+  # {#at_compile_time} or {#at_converge_time} to assert on the phase.
+  #
+  # @example
+  #   expect(chef_run).to create_template("/etc/foo").with(owner: "root")
+  #
   class ResourceMatcher
+    #
+    # Create a new matcher for a resource, action, and identity.
+    #
+    # @param [Symbol, String] resource_name
+    #   the type of resource, such as +:template+
+    #
+    # @param [Symbol] expected_action
+    #   the action the resource is expected to have performed
+    #
+    # @param [String, Regexp] expected_identity
+    #   the name or identity attribute of the resource
+    #
     def initialize(resource_name, expected_action, expected_identity)
       @resource_name     = resource_name
       @expected_action   = expected_action
       @expected_identity = expected_identity
     end
 
+    #
+    # Assert that the resource was declared with the given properties.
+    #
+    # May be chained more than once; the given properties are merged. Values are
+    # compared with +===+, so regular expressions and RSpec matchers work as
+    # well as literals.
+    #
+    # @example
+    #   expect(chef_run).to create_template("/etc/foo").with(mode: "0644")
+    #
+    # @param [Hash] parameters
+    #   the resource properties to assert on
+    #
+    # @return [self]
+    #
     def with(parameters = {})
       params.merge!(parameters)
       self
     end
 
+    #
+    # Assert that the resource performed its action at compile time.
+    #
+    # @raise [ArgumentError]
+    #   if {#at_converge_time} was already chained
+    #
+    # @return [self]
+    #
     def at_compile_time
       raise ArgumentError, "Cannot specify both .at_converge_time and .at_compile_time!" if @converge_time
 
@@ -20,6 +66,14 @@ module ChefSpec::Matchers
       self
     end
 
+    #
+    # Assert that the resource performed its action at converge time.
+    #
+    # @raise [ArgumentError]
+    #   if {#at_compile_time} was already chained
+    #
+    # @return [self]
+    #
     def at_converge_time
       raise ArgumentError, "Cannot specify both .at_compile_time and .at_converge_time!" if @compile_time
 
@@ -43,10 +97,27 @@ module ChefSpec::Matchers
       m.to_s.match?(/^with_(.+)$/) || super
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       %Q{#{@expected_action} #{@resource_name} "#{@expected_identity}"}
     end
 
+    #
+    # Determine whether a matching resource performed the expected action with
+    # the expected properties, in the expected phase.
+    #
+    # Marks the resource as covered in the coverage report as a side effect.
+    #
+    # @param [ChefSpec::SoloRunner, ChefSpec::ServerRunner] runner
+    #   the converged runner to inspect
+    #
+    # @return [true, false, nil]
+    #
     def matches?(runner)
       @runner = runner
 
@@ -56,6 +127,14 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # Falls back to describing similar resources in the run when no resource
+    # matched at all, which usually points at a typo or a missing platform.
+    #
+    # @return [String]
+    #
     def failure_message
       if resource
         if unmatched_parameters.empty?
@@ -83,6 +162,11 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       if resource
         message = %Q{expected "#{resource}" actions #{resource.performed_actions.inspect} to not exist}

--- a/lib/chefspec/matchers/state_attrs_matcher.rb
+++ b/lib/chefspec/matchers/state_attrs_matcher.rb
@@ -1,4 +1,13 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that a resource declares an exact set of state attributes.
+  #
+  # Built by {ChefSpec::API::StateAttrs#have_state_attrs}. The comparison is
+  # order-sensitive and exact, not a subset check.
+  #
+  # @example
+  #   expect(chef_run.my_resource("thing")).to have_state_attrs(:owner, :mode)
+  #
   class StateAttrsMatcher
     #
     # Create a new state_attrs matcher.
@@ -9,15 +18,35 @@ module ChefSpec::Matchers
       @expected_attrs = state_attrs.map(&:to_sym)
     end
 
+    #
+    # Determine whether the resource declares exactly the expected state
+    # attributes.
+    #
+    # @param [Chef::Resource] resource
+    #   the resource to inspect
+    #
+    # @return [true, false]
+    #
     def matches?(resource)
       @resource = resource
       @resource && matches_state_attrs?
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       %Q{have state attributes #{@expected_attrs.inspect}}
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       if @resource
         "expected #{state_attrs.inspect} to equal #{@expected_attrs.inspect}"
@@ -32,6 +61,11 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       if @resource
         "expected #{state_attrs.inspect} to not equal " \

--- a/lib/chefspec/matchers/subscribes_matcher.rb
+++ b/lib/chefspec/matchers/subscribes_matcher.rb
@@ -1,13 +1,39 @@
 module ChefSpec::Matchers
+  #
+  # Asserts that a resource subscribed to another resource.
+  #
+  # Built by {ChefSpec::API::Subscriptions#subscribe_to}. Subscriptions are the
+  # inverse of notifications, so this matcher resolves the resource being
+  # subscribed to and delegates the actual check to {NotificationsMatcher}.
+  #
+  # @example
+  #   expect(chef_run.service("apache2")).to subscribe_to("template[/etc/foo]")
+  #     .on(:restart).delayed
+  #
   class SubscribesMatcher
     include ChefSpec::Normalize
 
+    #
+    # Create a new matcher for the given resource signature.
+    #
+    # @param [String] signature
+    #   the subscribed-to resource in +type[name]+ form, such as
+    #   +"template[/etc/foo]"+
+    #
     def initialize(signature)
       match = signature.match(/^([^\[]*)\[(.*)\]$/)
       @expected_resource_type = match[1]
       @expected_resource_name = match[2]
     end
 
+    #
+    # Determine whether the resource subscribed to the expected resource.
+    #
+    # @param [Chef::Resource] resource
+    #   the subscribing resource
+    #
+    # @return [true, false]
+    #
     def matches?(resource)
       @instance = ChefSpec::Matchers::NotificationsMatcher.new(resource.to_s)
 
@@ -37,34 +63,73 @@ module ChefSpec::Matchers
       end
     end
 
+    #
+    # Restrict the match to subscriptions for a specific action.
+    #
+    # @param [Symbol, String] action
+    #   the action the subscription must send, such as +:restart+
+    #
+    # @return [self]
+    #
     def on(action)
       @action = action
       self
     end
 
+    #
+    # Restrict the match to immediate subscriptions.
+    #
+    # @return [self]
+    #
     def immediately
       @immediately = true
       self
     end
 
+    #
+    # Restrict the match to delayed subscriptions.
+    #
+    # @return [self]
+    #
     def delayed
       @delayed = true
       self
     end
 
+    #
+    # Restrict the match to +before+ subscriptions.
+    #
+    # @return [self]
+    #
     def before
       @before = true
       self
     end
 
+    #
+    # The RSpec description for this matcher, used when an example has no
+    # explicit doc string.
+    #
+    # @return [String]
+    #
     def description
       @instance.description
     end
 
+    #
+    # The message shown when the matcher was expected to match but did not.
+    #
+    # @return [String]
+    #
     def failure_message
       @instance.failure_message
     end
 
+    #
+    # The message shown when the matcher was expected not to match but did.
+    #
+    # @return [String]
+    #
     def failure_message_when_negated
       @instance.failure_message_when_negated
     end

--- a/lib/chefspec/mixins/normalize.rb
+++ b/lib/chefspec/mixins/normalize.rb
@@ -1,4 +1,10 @@
 module ChefSpec
+  #
+  # Normalizes resource names so that matchers can compare them reliably.
+  #
+  # Chef resources may be referred to by symbol or string, and with dashes or
+  # underscores; this smooths over the difference.
+  #
   module Normalize
     #
     # Calculate the name of a resource, replacing dashes with underscores

--- a/lib/chefspec/policyfile.rb
+++ b/lib/chefspec/policyfile.rb
@@ -7,6 +7,13 @@ rescue LoadError
 end
 
 module ChefSpec
+  #
+  # Resolves cookbook dependencies with a Policyfile before the Chef run.
+  #
+  # Enabled by requiring +chefspec/policyfile+. Exports the Policyfile lock
+  # into a temporary directory and points +cookbook_path+ at it for the
+  # duration of the suite.
+  #
   class Policyfile
     class << self
       extend Forwardable

--- a/lib/chefspec/renderer.rb
+++ b/lib/chefspec/renderer.rb
@@ -5,6 +5,13 @@ rescue LoadError
 end
 
 module ChefSpec
+  #
+  # Renders the content a +template+, +file+, or +cookbook_file+ resource would
+  # have written, without touching the filesystem.
+  #
+  # Backs {ChefSpec::Matchers::RenderFileMatcher}. Templates are evaluated with
+  # the same helper modules and variables Chef would use.
+  #
   class Renderer
     include ChefSpec::Normalize
 

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -14,6 +14,16 @@ module ChefSpec
     end
 
     #
+    # Define the +create_+, +get_+, and +has_+ helpers for a Chef Infra Server
+    # entity, such as nodes or data bags.
+    #
+    # @param [Symbol] method
+    #   the singular entity name used to build the method names
+    # @param [Class] klass
+    #   the Chef class the entity deserializes into
+    # @param [String] key
+    #   the chef-zero data store key for the entity
+    #
     # @macro entity
     #   @method create_$1(name, data = {})
     #     Create a new $1 on the Chef Server

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -7,6 +7,19 @@ require_relative "server_methods"
 require_relative "solo_runner"
 
 module ChefSpec
+  #
+  # Converges a recipe against an in-memory Chef Infra Server.
+  #
+  # Use this instead of {ChefSpec::SoloRunner} when the cookbook searches,
+  # reads data bags, or otherwise talks to a server. The server is backed by
+  # chef-zero and is populated through {ChefSpec::ServerMethods}.
+  #
+  # @example
+  #   describe "example::default" do
+  #     platform "ubuntu"
+  #     let(:chef_run) { ChefSpec::ServerRunner.converge(described_recipe) }
+  #   end
+  #
   class ServerRunner < SoloRunner
     include ChefSpec::ServerMethods
 

--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -6,6 +6,19 @@ require "chef/providers"
 require "chef/resources"
 
 module ChefSpec
+  #
+  # Converges a recipe in memory, with no Chef Infra Server.
+  #
+  # This is the default runner. It builds a Fauxhai node for the requested
+  # platform, compiles the run list, and records the resulting resource
+  # collection for matchers to assert against. No provider actually runs.
+  #
+  # @example
+  #   describe "example::default" do
+  #     platform "ubuntu"
+  #     let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  #   end
+  #
   class SoloRunner
     #
     # Handy class method for just converging a runner if you do not care about

--- a/lib/chefspec/stubs/command_registry.rb
+++ b/lib/chefspec/stubs/command_registry.rb
@@ -2,7 +2,20 @@ require_relative "registry"
 
 module ChefSpec
   module Stubs
+    #
+    # Registry of shell command stubs declared by the example.
+    #
     class CommandRegistry < Registry
+      #
+      # Find the most recently registered stub matching the given command.
+      #
+      #
+      # @param [String] command
+      #   the command the cookbook tried to run
+      #
+      #
+      # @return [ChefSpec::Stubs::Stub, nil]
+      #
       def stub_for(command)
         @stubs.find { |stub| stub.command === command }
       end

--- a/lib/chefspec/stubs/command_stub.rb
+++ b/lib/chefspec/stubs/command_stub.rb
@@ -2,6 +2,9 @@ require_relative "stub"
 
 module ChefSpec
   module Stubs
+    #
+    # A stubbed shell command, created by +stub_command+.
+    #
     class CommandStub < Stub
       attr_reader :block
       attr_reader :command
@@ -12,11 +15,24 @@ module ChefSpec
         @block   = block
       end
 
+      #
+      # Set the value the stubbed command returns.
+      #
+      # @param [Object] value
+      #   the value to return
+      #
+      # @return [self]
+      #
       def and_return(value)
         @value = value
         self
       end
 
+      #
+      # The value this stub returns, evaluating the block if one was given.
+      #
+      # @return [Object]
+      #
       def result
         if @block
           @block.call
@@ -25,6 +41,12 @@ module ChefSpec
         end
       end
 
+      #
+      # The +stub_command+ call that would register this stub, shown in the
+      # "not stubbed" error message.
+      #
+      # @return [String]
+      #
       def signature
         if @block
           "stub_command(#{@command.inspect}) { # Ruby code }"

--- a/lib/chefspec/stubs/data_bag_item_registry.rb
+++ b/lib/chefspec/stubs/data_bag_item_registry.rb
@@ -2,7 +2,23 @@ require_relative "registry"
 
 module ChefSpec
   module Stubs
+    #
+    # Registry of data bag item stubs declared by the example.
+    #
     class DataBagItemRegistry < Registry
+      #
+      # Find the most recently registered stub matching the given data bag and item id.
+      #
+      #
+      # @param [String, Symbol] bag
+      #   the data bag the item lives in
+      #
+      # @param [String] id
+      #   the id of the item the cookbook tried to load
+      #
+      #
+      # @return [ChefSpec::Stubs::Stub, nil]
+      #
       def stub_for(bag, id)
         @stubs.find do |stub|
           stub.bag.to_s == bag.to_s && stub.id === id

--- a/lib/chefspec/stubs/data_bag_item_stub.rb
+++ b/lib/chefspec/stubs/data_bag_item_stub.rb
@@ -2,6 +2,9 @@ require_relative "stub"
 
 module ChefSpec
   module Stubs
+    #
+    # A stubbed data bag item, created by +stub_data_bag_item+.
+    #
     class DataBagItemStub < Stub
       attr_reader :block
       attr_reader :id
@@ -13,6 +16,12 @@ module ChefSpec
         @block = block
       end
 
+      #
+      # The +stub_data_bag_item+ call that would register this stub, shown in the
+      # "not stubbed" error message.
+      #
+      # @return [String]
+      #
       def signature
         if @block
           "stub_data_bag_item(#{@bag.inspect}, #{@id.inspect}) { # Ruby code }"

--- a/lib/chefspec/stubs/data_bag_registry.rb
+++ b/lib/chefspec/stubs/data_bag_registry.rb
@@ -2,7 +2,20 @@ require_relative "registry"
 
 module ChefSpec
   module Stubs
+    #
+    # Registry of data bag stubs declared by the example.
+    #
     class DataBagRegistry < Registry
+      #
+      # Find the most recently registered stub matching the given data bag.
+      #
+      #
+      # @param [String, Symbol] bag
+      #   the data bag the cookbook tried to load
+      #
+      #
+      # @return [ChefSpec::Stubs::Stub, nil]
+      #
       def stub_for(bag)
         @stubs.find do |stub|
           stub.bag.to_s == bag.to_s

--- a/lib/chefspec/stubs/data_bag_stub.rb
+++ b/lib/chefspec/stubs/data_bag_stub.rb
@@ -2,6 +2,9 @@ require_relative "stub"
 
 module ChefSpec
   module Stubs
+    #
+    # A stubbed data bag, created by +stub_data_bag+.
+    #
     class DataBagStub < Stub
       attr_reader :block
       attr_reader :bag
@@ -11,6 +14,12 @@ module ChefSpec
         @block = block
       end
 
+      #
+      # The +stub_data_bag+ call that would register this stub, shown in the
+      # "not stubbed" error message.
+      #
+      # @return [String]
+      #
       def signature
         if @block
           "stub_data_bag(#{@bag.inspect}) { # Ruby code }"

--- a/lib/chefspec/stubs/registry.rb
+++ b/lib/chefspec/stubs/registry.rb
@@ -1,5 +1,12 @@
 module ChefSpec
   module Stubs
+    #
+    # Base class for the singleton registries that hold stubs for an example.
+    #
+    # Stubs are inserted at the front of the list, so a stub declared later wins
+    # over an earlier one with the same signature. Subclasses implement
+    # {#stub_for} to define what "matching" means for their stub type.
+    #
     class Registry
       class << self
         extend Forwardable
@@ -15,15 +22,38 @@ module ChefSpec
         reset!
       end
 
+      #
+      # Discard every registered stub. Called between examples.
+      #
+      # @return [Array]
+      #
       def reset!
         @stubs = []
       end
 
+      #
+      # Add a stub to the front of the registry, so it takes precedence over any
+      # previously registered stub with the same signature.
+      #
+      # @param [ChefSpec::Stubs::Stub] stub
+      #   the stub to register
+      #
+      # @return [ChefSpec::Stubs::Stub]
+      #   the stub that was registered
+      #
       def register(stub)
         @stubs.insert(0, stub)
         stub
       end
 
+      #
+      # Find the stub matching the given arguments.
+      #
+      # @abstract Subclasses must implement this.
+      #
+      # @raise [ArgumentError]
+      #   always, unless overridden by a subclass
+      #
       def stub_for(*args)
         raise ArgumentError, "#stub_for is an abstract function"
       end

--- a/lib/chefspec/stubs/search_registry.rb
+++ b/lib/chefspec/stubs/search_registry.rb
@@ -2,7 +2,23 @@ require_relative "registry"
 
 module ChefSpec
   module Stubs
+    #
+    # Registry of search stubs declared by the example.
+    #
     class SearchRegistry < Registry
+      #
+      # Find the most recently registered stub matching the given index and query.
+      #
+      #
+      # @param [String, Symbol] type
+      #   the search index, such as +:node+
+      #
+      # @param [String] query
+      #   the search query the cookbook ran
+      #
+      #
+      # @return [ChefSpec::Stubs::Stub, nil]
+      #
       def stub_for(type, query = "*:*")
         @stubs.find do |stub|
           stub.type.to_s == type.to_s && stub.query === query

--- a/lib/chefspec/stubs/search_stub.rb
+++ b/lib/chefspec/stubs/search_stub.rb
@@ -2,6 +2,9 @@ require_relative "stub"
 
 module ChefSpec
   module Stubs
+    #
+    # A stubbed Chef search, created by +stub_search+.
+    #
     class SearchStub < Stub
       attr_reader :block
       attr_reader :query
@@ -13,6 +16,12 @@ module ChefSpec
         @block = block
       end
 
+      #
+      # The +stub_search+ call that would register this stub, shown in the
+      # "not stubbed" error message.
+      #
+      # @return [String]
+      #
       def signature
         if @block
           "stub_search(#{@type.inspect}, #{@query.inspect}) { # Ruby code }"

--- a/lib/chefspec/stubs/stub.rb
+++ b/lib/chefspec/stubs/stub.rb
@@ -1,18 +1,51 @@
 module ChefSpec
+  #
+  # Namespace for the stub and registry objects backing +stub_command+,
+  # +stub_search+, +stub_data_bag+, and +stub_data_bag_item+.
+  #
   module Stubs
+    #
+    # Base class for a single stubbed call.
+    #
+    # A stub records what it was asked to return and replays it on demand.
+    # Subclasses add the arguments that identify the call and implement
+    # +#signature+, which is what the "not stubbed" error prints as a suggestion.
+    #
     class Stub
       attr_reader :value
 
+      #
+      # Set the value the stubbed call returns.
+      #
+      # @param [Object] value
+      #   the value to return
+      #
+      # @return [self]
+      #
       def and_return(value)
         @value = value
         self
       end
 
+      #
+      # Raise an exception instead of returning a value.
+      #
+      # @param [Exception, Class] exception
+      #   the exception to raise
+      #
+      # @return [self]
+      #
       def and_raise(exception)
         @block = proc { raise exception }
         self
       end
 
+      #
+      # The value this stub returns, with hashes converted to +Mash+ so that
+      # cookbook code can use string or symbol keys interchangeably.
+      #
+      # @return [Object]
+      #
       def result
         if @block
           recursively_mashify(@block.call)

--- a/lib/chefspec/util.rb
+++ b/lib/chefspec/util.rb
@@ -1,4 +1,7 @@
 module ChefSpec
+  #
+  # Small string helpers shared across ChefSpec.
+  #
   module Util
     extend self
 

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,6 @@
 module ChefSpec
+  #
+  # The version of the ChefSpec gem. Bumped automatically on merge.
+  #
   VERSION = "9.4.20".freeze
 end

--- a/tasks/yard_coverage.rb
+++ b/tasks/yard_coverage.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+#
+# Fails if any public object in lib/ is missing YARD documentation.
+#
+# The check drives YARD's own statistics class rather than reimplementing its
+# rules, so it always agrees with what `yard stats --list-undoc` reports. Those
+# rules are subtler than they look: only public objects count, aliases and
+# constructors are skipped, and a docstring holding nothing but an invisible
+# tag (`@api private`) still counts as undocumented.
+#
+# Kept free of ChefSpec's own requires so it can run with nothing but the yard
+# gem installed, rather than needing the whole bundle resolved.
+#
+# Usage: bundle exec rake yard:coverage
+#        ruby tasks/yard_coverage.rb
+#
+
+require "stringio"
+require "yard"
+
+ROOT = File.expand_path("..", __dir__)
+
+# YARD logs its statistics table, plus parser warnings about Chef's anonymous
+# `prepend(Module.new do ... end)` patches that it cannot index. Capture all of
+# it so this script controls what reaches the terminal.
+captured = StringIO.new
+log.io = captured
+log.level = YARD::Logger::ERROR
+
+stats = YARD::CLI::Stats.new
+stats.run("--list-undoc", "--no-output", File.join(ROOT, "lib", "**", "*.rb"))
+
+unless stats.instance_variable_defined?(:@undoc_list)
+  abort "Could not read the undocumented object list from YARD::CLI::Stats. " \
+        "This check needs updating for yard #{YARD::VERSION}."
+end
+
+undocumented = Array(stats.instance_variable_get(:@undoc_list))
+percentage = captured.string[/[\d.]+% documented/] || "unknown coverage"
+
+if undocumented.empty?
+  puts "YARD documentation coverage: #{percentage}"
+  exit 0
+end
+
+warn "YARD documentation coverage: #{percentage}"
+warn ""
+warn "#{undocumented.size} public object(s) are missing YARD documentation:"
+warn ""
+undocumented.sort_by { |o| [o.file.to_s, o.path] }.each do |object|
+  location = [object.file&.sub("#{ROOT}/", "") || "-unknown-", object.line].compact.join(":")
+  warn "  #{object.path}  (#{location})"
+end
+warn ""
+warn "Every public class, module, constant, attribute, and method in lib/ needs"
+warn "a YARD comment. See the Documentation section of CONTRIBUTING.md."
+exit 1


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` already said documentation was expected, and YARD was already wired up — the rake task, the `yard` gem, and the `.yardoc` gitignore entry were all in place. But nothing ever checked, and coverage had drifted:

```
Before:  61.59% documented   (164 undocumented objects)
After:  100.00% documented   (0 undocumented objects)
```

The gap was not in obscure corners. Every matcher class, all 15 error classes, both runners, the whole stubs subsystem, and the `ChefSpec` module itself had no comment at all.

## What's here

**Documentation** — YARD comments for the 164 undocumented objects, following the existing house style (bare `#` lines opening and closing each block, `@param`/`@return` separated by bare `#` lines). Every changed line under `lib/` is a comment: **1267 added, 0 removed**, so no behavior can have changed.

**`.yardopts`** — so `yard doc` produces consistent output with the README as the front page. Markup is deliberately left at YARD's `rdoc` default: the existing docstrings use `+template+` rather than backticks, and switching to Markdown would render all of that literally.

**`tasks/yard_coverage.rb` + `rake yard:coverage`** — a local check that reports anything public without a comment, exiting non-zero and naming the offending `file:line`. It drives YARD's own `CLI::Stats` rather than reimplementing the rules, so it cannot disagree with `yard stats --list-undoc`. Worth knowing that those rules are subtler than they look:

- only public objects count — private and protected methods are exempt
- aliases and constructors are skipped
- a docstring made of nothing but an *invisible* tag still reads as undocumented, so `# @api private` on its own does not satisfy it (`@deprecated`, being visible, does)

My first attempt hand-rolled this and reported 63 false failures against `yard stats`' zero, which is exactly why it now defers to YARD.

**This is a local tool only — nothing is wired into CI, and no workflow files are touched by this PR.**

**`CONTRIBUTING.md`** gains the expectation plus the conventions behind it, including the RDoc-vs-Markdown gotcha and the rule that cross-gem references need `+Chef::Resource+` rather than `{Chef::Resource}`, since YARD cannot link to a class it has not parsed.

## Verification

| Check | Result |
| --- | --- |
| `rake yard:coverage` | passes, 100.00% |
| Check fails when a docblock is removed | verified — exits 1 naming the object and its `file:line` |
| `cookstyle --chefstyle -c .rubocop.yml` | 111 files, no offenses |
| `ruby -c` on all 74 files in `lib/` + `tasks/` | all parse |
| `yard doc` warnings | 25, identical set to `upstream/main` — no new warnings |
| Non-comment changes under `lib/` | none |

The warning comparison caught real problems on the way: my first pass added six `Cannot resolve link` warnings by writing `{Mash}` and `{Chef::Resource}` for classes that live in other gems. Those are now `+Mash+` and `+Chef::Resource+`.

**One caveat on what I could not verify:** I was unable to run the RSpec suite — `bundle install` currently fails building the Windows-only `win32-api` gem via the Chef git source. That is not specific to this branch: `upstream/main` fails CI on its last four commits including the current tip, and the other open PRs fail identically. Given the diff is comments-only, the risk is minimal, but the suite has genuinely not run against this.

## Types of changes

- [x] Documentation

## Checklist

- [x] All public classes, modules, constants, attributes, and methods in `lib/` are documented
- [x] No behavior changes — `lib/` diff is entirely comments
- [x] `yard doc` produces no new warnings
- [x] No CI changes
- [x] Lint passes